### PR TITLE
Performance optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=g++
 LDFLAGS += -lm -lboost_system -lboost_filesystem
-CCFLAGS = -g -std=c++11 -w
+CCFLAGS = -g -std=c++11 -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -O2
 SUBDIRS=src
 ROOT_DIR=$(shell pwd)
 OBJS_DIR=build/Cpp/obj

--- a/build/Cpp/Makefile
+++ b/build/Cpp/Makefile
@@ -1,6 +1,6 @@
 CC=g++
 LDFLAGS += -lm -lboost_system -lboost_filesystem
-CCFLAGS = -g -std=c++11 -w
+CCFLAGS = -g -std=c++11 -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -O2
 OBJS=*.o
 ODIR=obj
 BIN1=IOHprofiler_run_experiment

--- a/build/Cpp/configuration.ini
+++ b/build/Cpp/configuration.ini
@@ -79,3 +79,7 @@ update_triggers = true
 number_interval_triggers = 0
 number_target_triggers = 0
 base_evaluation_triggers = 1
+
+# Performance options. Currently only the number of threads used for the experiment.
+[performance]
+number_threads = 3

--- a/src/Problems/f_labs.hpp
+++ b/src/Problems/f_labs.hpp
@@ -8,6 +8,7 @@
 #ifndef _F_LABS_H
 #define _F_LABS_H
 
+#include <cstdint>
 #include "../Template/IOHprofiler_problem.hpp"
 
 class LABS : public IOHprofiler_problem<int> {
@@ -35,37 +36,25 @@ public:
     IOHprofiler_set_number_of_variables(dimension);
   };
 
-  double correlation(const std::vector<int> x, const int n, int k)
-  {
-    int x1,x2;
-    double result;
-    result = 0.0;
+  int64_t correlation(const std::vector<int> x, const int n, int k) {
+    int64_t result = 0;
     for (int i = 0 ; i < n - k; ++i) {
-        if (x[i] == 0) {
-          x1 = -1;
-        } else {
-          x1 = 1;
-        }
-        if (x[i + k] == 0) {
-          x2 = -1;
-        } else {
-          x2 = 1;
-        }
-        result += x1 * x2;
+        // x[i] and x[i+k] different = -1, otherwise 1, this logically gives:
+        //     result += 1 - 2*(x[i] != x[i+k]);
+        // But we can take out the +1 and 2* out of the loop.
+        result += x[i] != x[i+k];
     }
-    return result;
+    return n - k - 2*result;
   }
 
   double internal_evaluate(const std::vector<int> &x) {
-
-    int n = x.size();
-    double result = 0.0, cor;
+    size_t n = x.size();
+    int64_t result = 0, cor;
     for (int k = 1; k != n; ++k) {
       cor = correlation(x,n,k);
       result += cor * cor;
     }
-    result = (double)(n*n)/2.0/result;
-    return (double)result;
+    return double(n*n)/2.0/result;
   };
 
   static LABS * createInstance() {

--- a/src/Template/Experiments/IOHprofiler_configuration.hpp
+++ b/src/Template/Experiments/IOHprofiler_configuration.hpp
@@ -233,6 +233,8 @@ void readcfg(std::string filename){
   base_evaluation_triggers = get_Dict_int_vector(dict,"observer","base_evaluation_triggers",0,10);
   number_target_triggers = get_Dict_Int(dict,"observer","number_target_triggers");
   number_interval_triggers = get_Dict_Int(dict,"observer","number_interval_triggers");
+
+  number_threads = get_Dict_Int(dict,"performance","number_threads");
   };
 
   std::string get_suite_name() {
@@ -276,6 +278,10 @@ void readcfg(std::string filename){
     return this->number_interval_triggers;
   };
 
+  int get_number_threads() {
+    return this->number_threads;
+  }
+
 private:
   std::string cfgFile = "configuration.ini";
 
@@ -292,6 +298,7 @@ private:
   std::vector<int> base_evaluation_triggers;
   int number_target_triggers;
   int number_interval_triggers;
+  int number_threads;
 };
 
 #endif

--- a/src/Template/Experiments/IOHprofiler_experimenter.hpp
+++ b/src/Template/Experiments/IOHprofiler_experimenter.hpp
@@ -7,6 +7,7 @@
 #include "IOHprofiler_configuration.hpp"
 
 #include <mutex>
+#include <chrono>
 #include "../../ctpl_stl.h"
 
 
@@ -45,7 +46,7 @@ public:
   ~IOHprofiler_experimenter(){};
 
   void _run() {
-    std::clock_t c_start_overall = std::clock();
+    auto start_overall = std::chrono::high_resolution_clock::now();
 
     std::string info = "IOHprofiler_experiment\n";
     info += "Suite: " + this->configSuite->IOHprofiler_suite_get_suite_name() + "\n";
@@ -67,7 +68,7 @@ public:
         id += "_i" + std::to_string(current_problem->IOHprofiler_get_instance_id());
 
 
-        std::clock_t c_start = std::clock();
+        auto start = std::chrono::high_resolution_clock::now();
         print_info("Starting " + id + "\n");
 
         current_problem->reset_problem();
@@ -89,14 +90,14 @@ public:
           ++count;
         }
 
-        std::clock_t c_end = std::clock();
-        print_info("Finished " + id + " CPU Time " + std::to_string(1000.0 * (c_end-c_start) / CLOCKS_PER_SEC) + "ms\n");
+        auto end = std::chrono::high_resolution_clock::now();
+        print_info("Finished " + id + " Time " + std::to_string(std::chrono::duration<double>(end-start).count()) + "s\n");
       });
     }
     pool.stop(true);
 
-    std::clock_t c_end_overall = std::clock();
-    print_info("Total CPU Time " + std::to_string(1000.0 * (c_end_overall-c_start_overall) / CLOCKS_PER_SEC) + "ms\n");
+    auto end_overall = std::chrono::high_resolution_clock::now();
+    print_info("Total Time " + std::to_string(std::chrono::duration<double>(end_overall-start_overall).count()) + "s\n");
   };
 
   void _set_independent_runs(int n) {

--- a/src/Template/Experiments/IOHprofiler_experimenter.hpp
+++ b/src/Template/Experiments/IOHprofiler_experimenter.hpp
@@ -6,6 +6,9 @@
 #include "../Loggers/IOHprofiler_csv_logger.h"
 #include "IOHprofiler_configuration.hpp"
 
+#include <mutex>
+#include "../../ctpl_stl.h"
+
 
 template <class InputType> class IOHprofiler_experimenter {
 public:
@@ -51,45 +54,49 @@ public:
     info += "Dimension: " + vectorToString(this->configSuite->IOHprofiler_suite_get_dimension()) + "\n";
     print_info(info);
 
-    this->config_csv_logger->target_suite(this->configSuite->IOHprofiler_suite_get_suite_name());
+    ctpl::thread_pool pool(conf.get_number_threads());
+    for (size_t problem_nr = 0; problem_nr < configSuite->size(); ++problem_nr) {
+      pool.push([this, problem_nr](int _thread_id) {
+        std::shared_ptr<IOHprofiler_csv_logger> local_logger(new IOHprofiler_csv_logger(*config_csv_logger));
+        local_logger->target_suite(this->configSuite->IOHprofiler_suite_get_suite_name());
 
-    /// Problems are tested one by one until 'get_next_problem' returns NULL.
-    while (current_problem = configSuite->get_next_problem()) {
-      std::clock_t c_start = std::clock();
-      info = "f";
-      info += std::to_string(current_problem->IOHprofiler_get_problem_id());
-      info += "_d" + std::to_string(current_problem->IOHprofiler_get_number_of_variables());
-      info += "_i" + std::to_string(current_problem->IOHprofiler_get_instance_id());
-      print_info(info);
+        std::shared_ptr<IOHprofiler_problem<InputType>> current_problem = (*configSuite)[problem_nr];
+        std::string id = "f";
+        id += std::to_string(current_problem->IOHprofiler_get_problem_id());
+        id += "_d" + std::to_string(current_problem->IOHprofiler_get_number_of_variables());
+        id += "_i" + std::to_string(current_problem->IOHprofiler_get_instance_id());
 
-      this->config_csv_logger->target_problem(current_problem->IOHprofiler_get_problem_id(), 
-                                              current_problem->IOHprofiler_get_number_of_variables(), 
-                                              current_problem->IOHprofiler_get_instance_id(),
-                                              current_problem->IOHprofiler_get_problem_name());
 
-      algorithm(current_problem,this->config_csv_logger);
-      
-      print_info(".");
+        std::clock_t c_start = std::clock();
+        print_info("Starting " + id + "\n");
 
-      int count = 1;
-      while(independent_runs > count) {
-        current_problem = configSuite->get_current_problem();
-        this->config_csv_logger->target_problem(current_problem->IOHprofiler_get_problem_id(), 
-                                              current_problem->IOHprofiler_get_number_of_variables(), 
-                                              current_problem->IOHprofiler_get_instance_id(),
-                                              current_problem->IOHprofiler_get_problem_name());
-        algorithm(current_problem,this->config_csv_logger);
-        ++count;
+        current_problem->reset_problem();
+        local_logger->target_problem(current_problem->IOHprofiler_get_problem_id(), 
+                                     current_problem->IOHprofiler_get_number_of_variables(), 
+                                     current_problem->IOHprofiler_get_instance_id(),
+                                     current_problem->IOHprofiler_get_problem_name());
+        algorithm(current_problem,local_logger);
+        
+        int count = 1;
+        while(independent_runs > count) {
+          current_problem->reset_problem();
+          local_logger->target_problem(current_problem->IOHprofiler_get_problem_id(), 
+                                       current_problem->IOHprofiler_get_number_of_variables(), 
+                                       current_problem->IOHprofiler_get_instance_id(),
+                                       current_problem->IOHprofiler_get_problem_name());
+          algorithm(current_problem,local_logger);
+          indicate_progress();
+          ++count;
+        }
 
-        print_info(".");
-      }
-
-      std::clock_t c_end = std::clock();
-      print_info("CPU Time" + std::to_string(1000.0 * (c_end-c_start) / CLOCKS_PER_SEC) + "ms\n");
+        std::clock_t c_end = std::clock();
+        print_info("Finished " + id + " CPU Time " + std::to_string(1000.0 * (c_end-c_start) / CLOCKS_PER_SEC) + "ms\n");
+      });
     }
+    pool.stop(true);
 
     std::clock_t c_end_overall = std::clock();
-    print_info("Total CPU Time" + std::to_string(1000.0 * (c_end_overall-c_start_overall) / CLOCKS_PER_SEC) + "ms\n");
+    print_info("Total CPU Time " + std::to_string(1000.0 * (c_end_overall-c_start_overall) / CLOCKS_PER_SEC) + "ms\n");
   };
 
   void _set_independent_runs(int n) {
@@ -97,7 +104,18 @@ public:
   }
 
   void print_info(std::string info) {
+    std::lock_guard<std::mutex> guard(output_mutex);
+    if (this->last_output_is_progress) {
+        std::cout << "\n";
+    }
     std::cout << info << std::flush;
+    this->last_output_is_progress = false;
+  }
+
+  void indicate_progress() {
+    std::lock_guard<std::mutex> guard(output_mutex);
+    std::cout << "." << std::flush;
+    this->last_output_is_progress = true;
   }
   
   std::string vectorToString(std::vector<int> v) {
@@ -120,6 +138,8 @@ private:
   std::shared_ptr<IOHprofiler_problem<InputType>> current_problem;
   std::shared_ptr<IOHprofiler_csv_logger> config_csv_logger;
   int independent_runs = 1;
+  std::mutex output_mutex;
+  bool last_output_is_progress;
 
   _algorithm *algorithm;
 };

--- a/src/Template/IOHprofiler_observer.hpp
+++ b/src/Template/IOHprofiler_observer.hpp
@@ -22,7 +22,8 @@ public:
   IOHprofiler_observer() {};
   ~IOHprofiler_observer() {};
 
-  IOHprofiler_observer(const IOHprofiler_observer &) = delete;
+  // Allow copies.
+  // IOHprofiler_observer(const IOHprofiler_observer &) = delete;
   IOHprofiler_observer &operator = (const IOHprofiler_observer&) = delete;
   
   void set_complete_flag(bool complete_flag) {

--- a/src/Template/Loggers/IOHprofiler_csv_logger.cpp
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.cpp
@@ -13,7 +13,7 @@ void IOHprofiler_csv_logger::activate_logger() {
 
 int IOHprofiler_csv_logger::openIndex() { 
   std::string experiment_folder_name = IOHprofiler_experiment_folder_name();
-  IOHprofiler_create_folder(experiment_folder_name);
+  return IOHprofiler_create_folder(experiment_folder_name);
 }
 
 

--- a/src/Template/Loggers/IOHprofiler_csv_logger.cpp
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.cpp
@@ -186,41 +186,46 @@ void IOHprofiler_csv_logger::write_line(const size_t &evaluations, const double 
     this->write_header();
   }
 
-  std::string written_line = std::to_string(evaluations) + " " + std::to_string(y) + " "
-                           + std::to_string(best_so_far_y) + " " + std::to_string(transformed_y) + " "
-                           + std::to_string(best_so_far_transformed_y);
-  
-  if (this->logging_parameters.size() != 0) {
-    for (size_t i = 0; i != this->logging_parameters.size(); i++) {
-      written_line += " ";
-      written_line += std::to_string(*logging_parameters[i]);
+  bool need_write =  complete_trigger() || interval_trigger(evaluations) ||
+                     update_trigger(transformed_y) || time_points_trigger(evaluations);
+
+  if (need_write) {
+    std::string written_line = std::to_string(evaluations) + " " + std::to_string(y) + " "
+                             + std::to_string(best_so_far_y) + " " + std::to_string(transformed_y) + " "
+                             + std::to_string(best_so_far_transformed_y);
+    
+    if (this->logging_parameters.size() != 0) {
+      for (size_t i = 0; i != this->logging_parameters.size(); i++) {
+        written_line += " ";
+        written_line += std::to_string(*logging_parameters[i]);
+      }
     }
-  }
-  
-  written_line += '\n';
-  if (complete_trigger()) {
-    if (!this->cdat.is_open()) {
-      IOH_error("*.cdat file is not open");
+    
+    written_line += '\n';
+    if (complete_trigger()) {
+      if (!this->cdat.is_open()) {
+        IOH_error("*.cdat file is not open");
+      }
+      this->cdat << written_line;
     }
-    this->cdat << written_line;
-  }
-  if (interval_trigger(evaluations)) {
-    if (!this->idat.is_open()) {
-      IOH_error("*.idat file is not open");
+    if (interval_trigger(evaluations)) {
+      if (!this->idat.is_open()) {
+        IOH_error("*.idat file is not open");
+      }
+      this->idat << written_line;
     }
-    this->idat << written_line;
-  }
-  if (update_trigger(transformed_y)) {
-    if (!this->dat.is_open()) {
-      IOH_error("*.dat file is not open");
+    if (update_trigger(transformed_y)) {
+      if (!this->dat.is_open()) {
+        IOH_error("*.dat file is not open");
+      }
+      this->dat << written_line;
     }
-    this->dat << written_line;
-  }
-  if (time_points_trigger(evaluations)) {
-    if (!this->tdat.is_open()) {
-      IOH_error("*.tdat file is not open");
+    if (time_points_trigger(evaluations)) {
+      if (!this->tdat.is_open()) {
+        IOH_error("*.tdat file is not open");
+      }
+      this->tdat << written_line;
     }
-    this->tdat << written_line;
   }
 
   if (transformed_y > this->found_optimal[0]) {

--- a/src/Template/Loggers/IOHprofiler_csv_logger.h
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.h
@@ -37,6 +37,33 @@ public:
     this->algorithm_name =  alg_name;
     this->algorithm_info = alg_info;
   }
+
+  IOHprofiler_csv_logger(const IOHprofiler_csv_logger& other) {
+    if (other.cdat.is_open()     ||
+        other.idat.is_open()     ||
+        other.dat.is_open()      ||
+        other.tdat.is_open()     ||
+        other.infoFile.is_open()) {
+        throw std::runtime_error("Attempted to copy logger that isn't clear.");
+    }
+
+    this->folder_name = other.folder_name;
+    this->output_directory = other.output_directory;
+    this->algorithm_name = other.algorithm_name;
+    this->algorithm_info = other.algorithm_info;
+    this->suite_name = other.suite_name;
+    this->dimension = other.dimension;
+    this->problem_id = other.problem_id;
+    this->instance = other.instance;
+    this->problem_name = other.problem_name;
+    this->found_optimal = other.found_optimal;
+    this->optimal_evaluations = other.optimal_evaluations;
+    this->last_dimension = other.last_dimension;
+    this->last_problem_id = other.last_problem_id;
+    this->logging_parameters = other.logging_parameters;
+    this->logging_parameters_name = other.logging_parameters_name;
+  }
+
   ~IOHprofiler_csv_logger() {
     this->clear_logger();
   };

--- a/src/ctpl_stl.h
+++ b/src/ctpl_stl.h
@@ -1,0 +1,251 @@
+/*********************************************************
+*
+*  Copyright (C) 2014 by Vitaliy Vitsentiy
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*********************************************************/
+
+
+#ifndef __ctpl_stl_thread_pool_H__
+#define __ctpl_stl_thread_pool_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <queue>
+
+
+
+// thread pool to run user's functors with signature
+//      ret func(int id, other_params)
+// where id is the index of the thread that runs the functor
+// ret is some return type
+
+
+namespace ctpl {
+
+    namespace detail {
+        template <typename T>
+        class Queue {
+        public:
+            bool push(T const & value) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->q.push(value);
+                return true;
+            }
+            // deletes the retrieved element, do not use for non integral types
+            bool pop(T & v) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                if (this->q.empty())
+                    return false;
+                v = this->q.front();
+                this->q.pop();
+                return true;
+            }
+            bool empty() {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                return this->q.empty();
+            }
+        private:
+            std::queue<T> q;
+            std::mutex mutex;
+        };
+    }
+
+    class thread_pool {
+
+    public:
+
+        thread_pool() { this->init(); }
+        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
+
+        // the destructor waits for all the functions in the queue to be finished
+        ~thread_pool() {
+            this->stop(true);
+        }
+
+        // get the number of running threads in the pool
+        int size() { return static_cast<int>(this->threads.size()); }
+
+        // number of idle threads
+        int n_idle() { return this->nWaiting; }
+        std::thread & get_thread(int i) { return *this->threads[i]; }
+
+        // change the number of threads in the pool
+        // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+        // nThreads must be >= 0
+        void resize(int nThreads) {
+            if (!this->isStop && !this->isDone) {
+                int oldNThreads = static_cast<int>(this->threads.size());
+                if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                    this->threads.resize(nThreads);
+                    this->flags.resize(nThreads);
+
+                    for (int i = oldNThreads; i < nThreads; ++i) {
+                        this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                        this->set_thread(i);
+                    }
+                }
+                else {  // the number of threads is decreased
+                    for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                        *this->flags[i] = true;  // this thread will finish
+                        this->threads[i]->detach();
+                    }
+                    {
+                        // stop the detached threads that were waiting
+                        std::unique_lock<std::mutex> lock(this->mutex);
+                        this->cv.notify_all();
+                    }
+                    this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                    this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+                }
+            }
+        }
+
+        // empty the queue
+        void clear_queue() {
+            std::function<void(int id)> * _f;
+            while (this->q.pop(_f))
+                delete _f; // empty the queue
+        }
+
+        // pops a functional wrapper to the original function
+        std::function<void(int)> pop() {
+            std::function<void(int id)> * _f = nullptr;
+            this->q.pop(_f);
+            std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+            std::function<void(int)> f;
+            if (_f)
+                f = *_f;
+            return f;
+        }
+
+        // wait for all computing threads to finish and stop all threads
+        // may be called asynchronously to not pause the calling thread while waiting
+        // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+        void stop(bool isWait = false) {
+            if (!isWait) {
+                if (this->isStop)
+                    return;
+                this->isStop = true;
+                for (int i = 0, n = this->size(); i < n; ++i) {
+                    *this->flags[i] = true;  // command the threads to stop
+                }
+                this->clear_queue();  // empty the queue
+            }
+            else {
+                if (this->isDone || this->isStop)
+                    return;
+                this->isDone = true;  // give the waiting threads a command to finish
+            }
+            {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->cv.notify_all();  // stop all waiting threads
+            }
+            for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+                    if (this->threads[i]->joinable())
+                        this->threads[i]->join();
+            }
+            // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+            // therefore delete them here
+            this->clear_queue();
+            this->threads.clear();
+            this->flags.clear();
+        }
+
+        template<typename F, typename... Rest>
+        auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+                );
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+        // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        template<typename F>
+        auto push(F && f) ->std::future<decltype(f(0))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+
+    private:
+
+        // deleted
+        thread_pool(const thread_pool &);// = delete;
+        thread_pool(thread_pool &&);// = delete;
+        thread_pool & operator=(const thread_pool &);// = delete;
+        thread_pool & operator=(thread_pool &&);// = delete;
+
+        void set_thread(int i) {
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]); // a copy of the shared ptr to the flag
+            auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+                std::atomic<bool> & _flag = *flag;
+                std::function<void(int id)> * _f;
+                bool isPop = this->q.pop(_f);
+                while (true) {
+                    while (isPop) {  // if there is anything in the queue
+                        std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+                        (*_f)(i);
+                        if (_flag)
+                            return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                        else
+                            isPop = this->q.pop(_f);
+                    }
+                    // the queue is empty here, wait for the next command
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    ++this->nWaiting;
+                    this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                    --this->nWaiting;
+                    if (!isPop)
+                        return;  // if the queue is empty and this->isDone == true or *flag then return
+                }
+            };
+            this->threads[i].reset(new std::thread(f)); // compiler may not support std::make_unique()
+        }
+
+        void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+        detail::Queue<std::function<void(int id)> *> q;
+        std::atomic<bool> isDone;
+        std::atomic<bool> isStop;
+        std::atomic<int> nWaiting;  // how many threads are waiting
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+}
+
+#endif // __ctpl_stl_thread_pool_H__


### PR DESCRIPTION
Fixes a small bug, adds `-O2` optimization to the makefile and adds rudimentary (per-problem) parallelism configurable by `performance.number_threads` in `configuration.ini`.

With these changes running the entire 100-dimensional PBO 1-23 experiment went from taking 13.5 minutes (814 seconds) to just 84 seconds on my machine.

This could probably still be reduced by a factor of 4 to 8 on my machine as the majority of the time is only spent on ~4 problems, and per-independent-run parallelism would then saturate all my cores rather than only 4. Unfortunately the way the current program is set up everything is very stateful and assumes serial execution. I don't understand how the logger works well enough to parallelize it on a per-independent-run basis. Perhaps the log file format needs to be changed for this.