### PR TITLE
add a static library + fix the CLEAN directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LDFLAGS =
 CCFLAGS = -g -std=c++11 -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -O2
 SUBDIRS=src
 ROOT_DIR=$(shell pwd)
+OBJS_DIR=obj
 
 T_DIR=
 ifeq ($(LANG),c++)
@@ -26,4 +27,5 @@ DEBUG:ECHO
 ECHO:
 	@echo $(SUBDIRS)
 CLEAN:
-	@rm $(OBJS_DIR)/*.o
+	@rm -f $(T_DIR)/$(OBJS_DIR)/*.o
+	@rm -f $(T_DIR)/$(OBJS_DIR)/*.a

--- a/build/Cpp/Makefile
+++ b/build/Cpp/Makefile
@@ -9,7 +9,8 @@ HPP_OBJS=${patsubst src/%.hpp, $(ODIR)/%.o, $(HPP_SOURCE)}
 BIN1=IOHprofiler_run_experiment
 BIN2=IOHprofiler_run_suite
 BIN3=IOHprofiler_run_problem
-all: PREPARE $(CPP_OBJS) $(HPP_OBJS) bin/$(BIN1) bin/$(BIN2) bin/$(BIN3)
+LIBIOH=libioh.a
+all: PREPARE $(CPP_OBJS) $(HPP_OBJS) bin/$(LIBIOH) bin/$(BIN1) bin/$(BIN2) bin/$(BIN3)
 PREPARE:
 	mkdir -p ./$(ODIR)
 	mkdir -p ./bin
@@ -17,6 +18,8 @@ $(CPP_OBJS):$(ODIR)/%.o:src/%.cpp
 	$(CC) ${CCFLAGS} -c -x c++ $^ -o $@ ${LDFLAGS}
 $(HPP_OBJS):$(ODIR)/%.o:src/%.hpp
 	$(CC) ${CCFLAGS} -c -x c++ $^ -o $@ ${LDFLAGS}
+bin/$(LIBIOH):${CPP_OBJS} ${HPP_OBJS}
+	ar rcs bin/$(LIBIOH) ${CPP_OBJS} ${HPP_OBJS}
 bin/$(BIN1):${CPP_OBJS} ${HPP_OBJS} IOHprofiler_run_experiment.cpp
 	cp configuration.ini bin/
 	$(CC) ${CCFLAGS} -pthread -o $@ $^  ${LDFLAGS}
@@ -28,3 +31,4 @@ CLEAN:
 	@rm -rf bin/IOHprofiler_run_experiment
 	@rm -rf bin/IOHprofiler_run_suite
 	@rm -rf bin/IOHprofiler_run_problem
+	@rm -f ./$(ODIR)/*.o ./$(ODIR)/*.a


### PR DESCRIPTION
Add a static library build directive, so as to ease link from third
party softwares: instead of having to indicate each object, the archive
alone is sufficient.

Fix the CLEAN directive of the high level Makefile to effectively remove
objects and the static library. The fix is minimal and do not modify the
existence of two separated directive in each subdirectories.