### PR TITLE
cleaner CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,63 +1,75 @@
-# 
+
+######################################################################################
+# Project settings
+######################################################################################
+
 cmake_minimum_required(VERSION 3.6)
 
-# set the project name and version
-project(IOHexperimenter VERSION 1.0)
-SET(EXECUTABLE_OUTPUT_PATH "build/Cpp/")
+enable_language(CXX) # C++
 
-# add the executable
-add_executable(IOHprofiler_run_experiment build/Cpp/IOHprofiler_run_experiment.cpp)
-add_executable(IOHprofiler_run_problem build/Cpp/IOHprofiler_run_problem.cpp)
-add_executable(IOHprofiler_run_suite build/Cpp/IOHprofiler_run_suite.cpp)
+## Current version
+set(VERSION_MAJOR 0 CACHE STRING "Major version number" )
+set(VERSION_MINOR 0 CACHE STRING "Minor version number" )
+set(VERSION_PATCH 0 CACHE STRING "Patch version number" )
+mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
+
+# set the project name and version
+project(IOHexperimenter VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+set(EXECUTABLE_OUTPUT_PATH "build/Cpp/")
 # specify the CXX FLAGS
-set(CMAKE_CXX_FLAGS "-g -std=c++11 -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -O2")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
+
+
+######################################################################################
+# Gather source files
+######################################################################################
 
 # set source file directorys and prepare for adding libraries.
-SET(PROBLEMS_BBOB_DIR "src/Problems/BBOB")
-FILE (GLOB PROBLEMS_BBOB_SRC "${PROBLEMS_BBOB_DIR}/*.cpp" "${PROBLEMS_BBOB_DIR}/*.hpp"  "${PROBLEMS_BBOB_DIR}/*.h")
+set(PROBLEMS_BBOB_DIR "src/Problems/BBOB")
+File(GLOB PROBLEMS_BBOB_SRC "${PROBLEMS_BBOB_DIR}/*.cpp" "${PROBLEMS_BBOB_DIR}/*.hpp"  "${PROBLEMS_BBOB_DIR}/*.h")
 
-SET(PROBLEMS_BBOB_COMMON_DIR "src/Problems/BBOB/bbob_common_used_functions")
-FILE (GLOB PROBLEMS_BBOB_COMMON_SRC "${PROBLEMS_BBOB_COMMON_DIR}/*.cpp" "${PROBLEMS_BBOB_COMMON_DIR}/*.hpp" "${PROBLEMS_BBOB_COMMON_DIR}/*.h")
+set(PROBLEMS_BBOB_COMMON_DIR "src/Problems/BBOB/bbob_common_used_functions")
+File(GLOB PROBLEMS_BBOB_COMMON_SRC "${PROBLEMS_BBOB_COMMON_DIR}/*.cpp" "${PROBLEMS_BBOB_COMMON_DIR}/*.hpp" "${PROBLEMS_BBOB_COMMON_DIR}/*.h")
 
-SET(PROBLEMS_COMMON_DIR "src/Problems/common_used_functions")
-FILE (GLOB PROBLEMS_COMMON_SRC "${PROBLEMS_COMMON_DIR}/*.cpp" "${PROBLEMS_COMMON_DIR}/*.hpp" "${PROBLEMS_COMMON_DIR}/*.h")
+set(PROBLEMS_COMMON_DIR "src/Problems/common_used_functions")
+File(GLOB PROBLEMS_COMMON_SRC "${PROBLEMS_COMMON_DIR}/*.cpp" "${PROBLEMS_COMMON_DIR}/*.hpp" "${PROBLEMS_COMMON_DIR}/*.h")
 
-SET(PROBLEMS_PBO_DIR "src/Problems/PBO")
-FILE (GLOB PROBLEMS_PBO_SRC "${PROBLEMS_PBO_DIR}/*.cpp" "${PROBLEMS_PBO_DIR}/*.hpp" "${PROBLEMS_PBO_DIR}/*.h")
+set(PROBLEMS_PBO_DIR "src/Problems/PBO")
+File(GLOB PROBLEMS_PBO_SRC "${PROBLEMS_PBO_DIR}/*.cpp" "${PROBLEMS_PBO_DIR}/*.hpp" "${PROBLEMS_PBO_DIR}/*.h")
 
-SET(PROBLEMS_WMODEL_DIR "src/Problems/WModel")
-FILE (GLOB PROBLEMS_WMODEL_SRC "${PROBLEMS_WMODEL_DIR}/*.cpp" "${PROBLEMS_WMODEL_DIR}/*.hpp" "${PROBLEMS_WMODEL_DIR}/*.h")
+set(PROBLEMS_WMODEL_DIR "src/Problems/WModel")
+File(GLOB PROBLEMS_WMODEL_SRC "${PROBLEMS_WMODEL_DIR}/*.cpp" "${PROBLEMS_WMODEL_DIR}/*.hpp" "${PROBLEMS_WMODEL_DIR}/*.h")
 
-SET(SUITES_DIR "src/Suites")
-FILE (GLOB SUITES_SRC "${SUITES_DIR}/*.cpp" "${SUITES_DIR}/*.hpp" "${SUITES_DIR}/*.h")
+set(SUITES_DIR "src/Suites")
+File(GLOB SUITES_SRC "${SUITES_DIR}/*.cpp" "${SUITES_DIR}/*.hpp" "${SUITES_DIR}/*.h")
 
-SET(TEMPLATE_DIR "src/Template")
-FILE (GLOB TEMPLATE_SRC "${TEMPLATE_DIR}/*.cpp" "${TEMPLATE_DIR}/*.hpp" "${TEMPLATE_DIR}/*.h")
+set(TEMPLATE_DIR "src/Template")
+File(GLOB TEMPLATE_SRC "${TEMPLATE_DIR}/*.cpp" "${TEMPLATE_DIR}/*.hpp" "${TEMPLATE_DIR}/*.h")
 
-SET(TEMPLATE_EXPERIMENTS_DIR "src/Template/Experiments")
-FILE (GLOB TEMPLATE_EXPERIMENTS_SRC "${TEMPLATE_EXPERIMENTS_DIR}/*.cpp" "${TEMPLATE_EXPERIMENTS_DIR}/*.hpp" "${TEMPLATE_EXPERIMENTS_DIR}/*.h")
+set(TEMPLATE_EXPERIMENTS_DIR "src/Template/Experiments")
+File(GLOB TEMPLATE_EXPERIMENTS_SRC "${TEMPLATE_EXPERIMENTS_DIR}/*.cpp" "${TEMPLATE_EXPERIMENTS_DIR}/*.hpp" "${TEMPLATE_EXPERIMENTS_DIR}/*.h")
 
-SET(TEMPLATE_LOGGERS_DIR "src/Template/Loggers")
-FILE (GLOB TEMPLATE_LOGGERS_SRC "${TEMPLATE_LOGGERS_DIR}/*.cpp" "${TEMPLATE_LOGGERS_DIR}/*.hpp" "${TEMPLATE_LOGGERS_DIR}/*.h")
+set(TEMPLATE_LOGGERS_DIR "src/Template/Loggers")
+File(GLOB TEMPLATE_LOGGERS_SRC "${TEMPLATE_LOGGERS_DIR}/*.cpp" "${TEMPLATE_LOGGERS_DIR}/*.hpp" "${TEMPLATE_LOGGERS_DIR}/*.h")
 
-SET(IOHEXPERIMENTER_SRC 
+set(IOHEXPERIMENTER_SRC 
   "${PROBLEMS_COMMON_SRC}"
-	"${PROBLEMS_BBOB_SRC}"
-	"${PROBLEMS_BBOB_COMMON_SRC}"
-	"${PROBLEMS_PBO_SRC}"
+  "${PROBLEMS_BBOB_SRC}"
+  "${PROBLEMS_BBOB_COMMON_SRC}"
+  "${PROBLEMS_PBO_SRC}"
   "${PROBLEMS_WMODEL_SRC}"
   "${SUITES_SRC}"
-	"${TEMPLATE_SRC}"
+  "${TEMPLATE_SRC}"
   "${TEMPLATE_EXPERIMENTS_SRC}"
-	"${TEMPLATE_LOGGERS_SRC}"
+  "${TEMPLATE_LOGGERS_SRC}"
 )
 
-SET(IOHEXPERIMENTER_DIR 
+set(IOHEXPERIMENTER_DIR 
   "${PROBLEMS_COMMON_DIR}"
   "${PROBLEMS_BBOB_DIR}"
   "${PROBLEMS_BBOB_COMMON_DIR}"
@@ -69,6 +81,11 @@ SET(IOHEXPERIMENTER_DIR
   "${TEMPLATE_LOGGERS_DIR}"
 )
 
+
+######################################################################################
+# Binaries
+######################################################################################
+
 # add the binary tree to the search path for include files
 # so that we will find header files of IOHexperimenter.
 include_directories(${IOHEXPERIMENTER_DIR})
@@ -76,11 +93,22 @@ include_directories(${IOHEXPERIMENTER_DIR})
 # add the IOH library
 add_library(IOH ${IOHEXPERIMENTER_SRC})
 
+# add the executable
+add_executable(IOHprofiler_run_experiment build/Cpp/IOHprofiler_run_experiment.cpp)
+add_executable(IOHprofiler_run_problem build/Cpp/IOHprofiler_run_problem.cpp)
+add_executable(IOHprofiler_run_suite build/Cpp/IOHprofiler_run_suite.cpp)
+
 # link the IOH library to executable files.
 target_link_libraries(IOHprofiler_run_experiment IOH)
-target_link_libraries(IOHprofiler_run_problem IOH)
-target_link_libraries(IOHprofiler_run_suite IOH)
+target_link_libraries(IOHprofiler_run_problem    IOH)
+target_link_libraries(IOHprofiler_run_suite      IOH)
+
+
+######################################################################################
+# Installation
+######################################################################################
 
 # install. set name of the installed library as 'IOH'.
-install (TARGETS IOH DESTINATION lib)
-install (FILES ${IOHEXPERIMENTER_SRC} DESTINATION include)
+install(TARGETS IOH DESTINATION lib)
+install(FILES ${IOHEXPERIMENTER_SRC} DESTINATION include)
+


### PR DESCRIPTION
- Remove useless flags:
    -g is added in Debug builds,
    -O2 is contradictory and added in Release builds.
- Add warning flags up to pedantic.
- Group directives in related sections:
    - move executable at the end with the library.
- Add version number management.
- Use lower case, no space before parens and avoid tabs everywhere.