### PR TITLE
feat fix: better error handling

### DIFF
--- a/src/Template/IOHprofiler_common.cpp
+++ b/src/Template/IOHprofiler_common.cpp
@@ -1,18 +1,18 @@
 #include "IOHprofiler_common.h"
 
 void IOH_error(std::string error_info) {
-  std::cout << "IOH_ERROR_INFO : " << error_info << std::endl;
-  exit(1);
+  std::cerr << "IOH_ERROR_INFO: " << error_info << std::endl;
+  throw std::runtime_error(error_info);
 }
 
 void IOH_warning(std::string warning_info) {
-  std::cout << "IOH_WARNING_INFO : " << warning_info << std::endl;
+  std::cerr << "IOH_WARNING_INFO: " << warning_info << std::endl;
 }
 
 void IOH_log(std::string log_info) {
-  std::cout << "IOH_LOG_INFO : " << log_info << std::endl;
+  std::clog << "IOH_LOG_INFO: " << log_info << std::endl;
 }
 
 void IOH_log(std::string log_info, std::ofstream &log_stream) {
-  log_stream << "IOH_LOG_INFO : " << log_info << std::endl;
+  log_stream << "IOH_LOG_INFO: " << log_info << std::endl;
 }

--- a/src/Template/Loggers/IOHprofiler_csv_logger.cpp
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.cpp
@@ -35,7 +35,7 @@ int IOHprofiler_csv_logger::IOHprofiler_create_folder(std::string folder_name) {
 #endif
     return 1;
   } else {
-    IOH_error("Error on creating directory" + folder_name);
+    IOH_error("Error on creating directory " + folder_name);
     return 0;
   }
 }


### PR DESCRIPTION
- Use the dedicated standard output (error/warning: cerr, log: clog),
which correspond to users expectations and allows redirections.
- Make IOH_error throw an exception instead of exiting. This allow the
calling third party app to be warned and handle the problem in its own
way.
- Add a missing space in an error message and follow english typography.

