### PR TITLE
Bug fix: Optimal values of F3, F16-F18, and F23 of BBOB suite

### DIFF
--- a/IOHprofiler.i
+++ b/IOHprofiler.i
@@ -15,6 +15,8 @@
 %shared_ptr(IOHprofiler_problem< double >)
 %shared_ptr(IOHprofiler_suite< double >)
 %shared_ptr(IOHprofiler_suite< int >)
+%shared_ptr(double)
+%shared_ptr(int)
 
 %shared_ptr(OneMax)
 %shared_ptr(LeadingOnes)

--- a/src/IOHprofiler_problem.hpp
+++ b/src/IOHprofiler_problem.hpp
@@ -379,6 +379,13 @@ template <class InputType> void IOHprofiler_problem<InputType>::calc_optimal() {
     /// todo. Make Exception.
     /// Do not apply transformation on best_variables as calculating optimal
     if (this->number_of_objectives == 1) {
+      /// This only works for F4, F16-18, and F23 of BBOB suite.
+      if(this->problem_type == "bbob") {
+        Coco_Transformation_Data::raw_x.clear();
+        for (int i = 0; i != this->best_variables.size(); ++i) {
+          Coco_Transformation_Data::raw_x.push_back(this->best_variables[i]);
+        }
+      }
       this->optimal[0] = internal_evaluate(this->best_variables);
     } else {
       /// this->optimal = internal_evaluate_multi(this->best_variables);


### PR DESCRIPTION
This is caused by the transformation on objectives, in which the input variables are applied.