### PR TITLE
[New feature] a logger which computes ECDF on the fly + Python interface toward external problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@
 *.pdf
 *.html
 .*
-
+tags
 !/.Rbuildignore
 !/.gitignore
 __pycache__
+debug/
+release/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,40 @@
-#
+
+######################################################################################
+# Project settings
+######################################################################################
+
 cmake_minimum_required(VERSION 3.6)
 
-# set the project name and version
-project(IOHexperimenter VERSION 1.0)
-SET(EXECUTABLE_OUTPUT_PATH "build/Cpp/")
+enable_language(CXX) # C++
 
-# add the executable
-add_executable(IOHprofiler_run_experiment ./build/Cpp/IOHprofiler_run_experiment.cpp)
-add_executable(IOHprofiler_run_problem ./build/Cpp/IOHprofiler_run_problem.cpp)
-add_executable(IOHprofiler_run_suite ./build/Cpp/IOHprofiler_run_suite.cpp)
+## Current version
+set(VERSION_MAJOR 0 CACHE STRING "Major version number" )
+set(VERSION_MINOR 0 CACHE STRING "Minor version number" )
+set(VERSION_PATCH 0 CACHE STRING "Patch version number" )
+mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
+
+# set the project name and version
+project(IOHexperimenter VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 
 # specify the C++ standard
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+set(EXECUTABLE_OUTPUT_PATH "build/Cpp/")
 # specify the CXX FLAGS
-set(CMAKE_CXX_FLAGS "-g -std=c++11 -Wall -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -O2")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option(ENABLE_TESTS "Build tests binaries" ON)
+endif()
+
+
+######################################################################################
+# Gather source files
+######################################################################################
 
 # set source file directorys and prepare for adding libraries.
+<<<<<<< HEAD
 SET(PROBLEMS_BBOB_DIR "src/Problems/BBOB")
 FILE (GLOB PROBLEMS_BBOB_SRC "${PROBLEMS_BBOB_DIR}/*.hpp")
 FILE (GLOB PROBLEMS_BBOB_INCLUDE "${PROBLEMS_BBOB_DIR}/*.hpp")
@@ -57,14 +74,14 @@ FILE (GLOB TEMPLATE_LOGGERS_INCLUDE "${TEMPLATE_LOGGERS_DIR}/*.h" "${TEMPLATE_LO
 
 SET(IOHEXPERIMENTER_SRC
   "${PROBLEMS_COMMON_SRC}"
-	"${PROBLEMS_BBOB_SRC}"
-	"${PROBLEMS_BBOB_COMMON_SRC}"
-	"${PROBLEMS_PBO_SRC}"
+  "${PROBLEMS_BBOB_SRC}"
+  "${PROBLEMS_BBOB_COMMON_SRC}"
+  "${PROBLEMS_PBO_SRC}"
   "${PROBLEMS_WMODEL_SRC}"
   "${SUITES_SRC}"
-	"${TEMPLATE_SRC}"
+  "${TEMPLATE_SRC}"
   "${TEMPLATE_EXPERIMENTS_SRC}"
-	"${TEMPLATE_LOGGERS_SRC}"
+  "${TEMPLATE_LOGGERS_SRC}"
 )
 
 SET(IOHEXPERIMENTER_DIR
@@ -92,6 +109,10 @@ SET(IOHEXPERIMENTER_INCLUDE
 )
 
 
+######################################################################################
+# Binaries
+######################################################################################
+
 # add the binary tree to the search path for include files
 # so that we will find header files of IOHexperimenter.
 include_directories(${IOHEXPERIMENTER_DIR})
@@ -99,10 +120,24 @@ include_directories(${IOHEXPERIMENTER_DIR})
 # add the IOH library
 add_library(IOH ${IOHEXPERIMENTER_SRC})
 
+# add the executable
+add_executable(IOHprofiler_run_experiment build/Cpp/IOHprofiler_run_experiment.cpp)
+add_executable(IOHprofiler_run_problem build/Cpp/IOHprofiler_run_problem.cpp)
+add_executable(IOHprofiler_run_suite build/Cpp/IOHprofiler_run_suite.cpp)
+
 # link the IOH library to executable files.
-target_link_libraries(IOHprofiler_run_experiment IOH )
-target_link_libraries(IOHprofiler_run_problem IOH)
-target_link_libraries(IOHprofiler_run_suite IOH)
+target_link_libraries(IOHprofiler_run_experiment IOH)
+target_link_libraries(IOHprofiler_run_problem    IOH)
+target_link_libraries(IOHprofiler_run_suite      IOH)
+
+if(ENABLE_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+######################################################################################
+# Installation
+######################################################################################
 
 # install. set name of the installed library as 'IOH'.
 install (TARGETS IOH DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,26 @@ endif()
 
 
 ######################################################################################
+# Dependencies
+######################################################################################
+
+option(ENABLE_PYTHON_PROBLEMS "Enable the ability to call external Python modules as if they were an IOH problem" OFF)
+if(ENABLE_PYTHON_PROBLEMS)
+    find_package(PythonLibs REQUIRED)
+    if(NOT PYTHONLIBS_FOUND)
+        message(FATAL_ERROR "You requested to build Python problems, but Python cannot be found")
+    else()
+        add_definitions(-DWITH_PYTHON_PROBLEMS)
+        include_directories(${PYTHON_INCLUDE_DIRS})
+    endif()
+endif()
+
+
+######################################################################################
 # Gather source files
 ######################################################################################
 
 # set source file directorys and prepare for adding libraries.
-<<<<<<< HEAD
 SET(PROBLEMS_BBOB_DIR "src/Problems/BBOB")
 FILE (GLOB PROBLEMS_BBOB_SRC "${PROBLEMS_BBOB_DIR}/*.hpp")
 FILE (GLOB PROBLEMS_BBOB_INCLUDE "${PROBLEMS_BBOB_DIR}/*.hpp")
@@ -54,6 +69,10 @@ FILE (GLOB PROBLEMS_PBO_INCLUDE "${PROBLEMS_PBO_DIR}/*.hpp" )
 SET(PROBLEMS_WMODEL_DIR "src/Problems/WModel")
 FILE (GLOB PROBLEMS_WMODEL_SRC  "${PROBLEMS_WMODEL_DIR}/*.hpp")
 FILE (GLOB PROBLEMS_WMODEL_INCLUDE  "${PROBLEMS_WMODEL_DIR}/*.hpp")
+
+SET(PROBLEMS_PYTHON_DIR "src/Problems/Python")
+FILE (GLOB PROBLEMS_PYTHON_SRC "")
+FILE (GLOB PROBLEMS_PYTHON_INCLUDE "${PROBLEMS_Python_DIR}/*.h" "${PROBLEMS_Python_DIR}/*.hpp")
 
 SET(SUITES_DIR "src/Suites")
 FILE (GLOB SUITES_SRC "${SUITES_DIR}/*.h" "${SUITES_DIR}/*.hpp")
@@ -78,6 +97,7 @@ SET(IOHEXPERIMENTER_SRC
   "${PROBLEMS_BBOB_COMMON_SRC}"
   "${PROBLEMS_PBO_SRC}"
   "${PROBLEMS_WMODEL_SRC}"
+  "${PROBLEMS_PYTHON_SRC}"
   "${SUITES_SRC}"
   "${TEMPLATE_SRC}"
   "${TEMPLATE_EXPERIMENTS_SRC}"
@@ -90,6 +110,7 @@ SET(IOHEXPERIMENTER_DIR
   "${PROBLEMS_BBOB_COMMON_DIR}"
   "${PROBLEMS_PBO_DIR}"
   "${PROBLEMS_WMODEL_DIR}"
+  "${PROBLEMS_PYTHON_DIR}"
   "${SUITES_DIR}"
   "${TEMPLATE_DIR}"
   "${TEMPLATE_EXPERIMENTS_DIR}"
@@ -102,11 +123,22 @@ SET(IOHEXPERIMENTER_INCLUDE
   "${PROBLEMS_BBOB_COMMON_INCLUDE}"
   "${PROBLEMS_PBO_INCLUDE}"
   "${PROBLEMS_WMODEL_INCLUDE}"
+  "${PROBLEMS_PYTHON_INCLUDE}"
   "${SUITES_INCLUDE}"
   "${TEMPLATE_INCLUDE}"
   "${TEMPLATE_EXPERIMENTS_INCLUDE}"
   "${TEMPLATE_LOGGERS_INCLUDE}"
 )
+
+if(ENABLE_PYTHON_PROBLEMS AND PYTHONLIBS_FOUND)
+    SET(PROBLEMS_PYTHON_DIR "src/Problems/Python")
+    # FILE(GLOB PROBLEMS_PYTHON_SRC  "${PROBLEMS_PYTHON_DIR}/*.cpp")
+    FILE(GLOB PROBLEMS_PYTHON_INCLUDE  "${PROBLEMS_PYTHON_DIR}/*.h")
+    FILE(GLOB PROBLEMS_PYTHON_INCLUDE  "${PROBLEMS_PYTHON_DIR}/*.hpp")
+
+    list(APPEND IOHEXPERIMENTER_SRC ${PROBLEMS_PYTHON_SRC})
+    list(APPEND IOHEXPERIMENTER_DIR ${PROBLEMS_PYTHON_DIR})
+endif()
 
 
 ######################################################################################

--- a/build/Cpp/IOHprofiler_run_experiment.cpp
+++ b/build/Cpp/IOHprofiler_run_experiment.cpp
@@ -24,7 +24,7 @@ int mutation(std::vector<int> &x, double mutation_rate) {
   return result;
 }
 
-template<class InputType> double evaluate(std::shared_ptr<IOHprofiler_problem<InputType> > problem, std::shared_ptr<IOHprofiler_csv_logger> logger,const std::vector<InputType> &x) {
+template<class InputType> double evaluate(std::shared_ptr<IOHprofiler_problem<InputType> > problem, std::shared_ptr<IOHprofiler_csv_logger<int>> logger,const std::vector<InputType> &x) {
   double result;
   result = problem->evaluate(x);
   if (problem->IOHprofiler_get_problem_type() == "pseudo_Boolean_problem") {
@@ -39,7 +39,7 @@ template<class InputType> double evaluate(std::shared_ptr<IOHprofiler_problem<In
 
 /// This is an (1+1)_EA with static mutation rate = 1/n.
 /// An example for discrete optimization problems, such as PBO suite.
-void evolutionary_algorithm(std::shared_ptr<IOHprofiler_problem<int> > problem, std::shared_ptr<IOHprofiler_csv_logger> logger) {
+void evolutionary_algorithm(std::shared_ptr<IOHprofiler_problem<int> > problem, std::shared_ptr<IOHprofiler_csv_logger<int>> logger) {
   /// Declaration for variables in the algorithm
   std::vector<int> x;
   std::vector<int> x_star;
@@ -76,7 +76,7 @@ void evolutionary_algorithm(std::shared_ptr<IOHprofiler_problem<int> > problem, 
 
 /// This is an (1+1)_EA with static mutation rate = 1/n.
 /// An example for continuous optimization problems, such as BBOB suite.
-void random_search(std::shared_ptr<IOHprofiler_problem<double> > problem, std::shared_ptr<IOHprofiler_csv_logger> logger) {
+void random_search(std::shared_ptr<IOHprofiler_problem<double> > problem, std::shared_ptr<IOHprofiler_csv_logger<int>> logger) {
   /// Declaration for variables in the algorithm
   std::vector<double> x(problem->IOHprofiler_get_number_of_variables());
   double y,best_y;

--- a/build/Cpp/IOHprofiler_run_problem.cpp
+++ b/build/Cpp/IOHprofiler_run_problem.cpp
@@ -34,7 +34,7 @@ void _run_w_model() {
 
 
   std::vector<int> time_points{1,2,5};
-  IOHprofiler_csv_logger logger("./","run_w_model","EA","EA");
+  IOHprofiler_csv_logger<int> logger("./","run_w_model","EA","EA");
   logger.set_complete_flag(true);
   logger.set_interval(0);
   logger.set_time_points(time_points,10);
@@ -123,7 +123,7 @@ void _run_problem() {
   /// If no logger is added, there will be not any output files, but users
   /// can still get fitness values.
   std::vector<int> time_points{1,2,5};
-  IOHprofiler_csv_logger logger("./","run_problem","EA","EA");
+  IOHprofiler_csv_logger<int> logger("./","run_problem","EA","EA");
   logger.set_complete_flag(true);
   logger.set_interval(0);
   logger.set_time_points(time_points,10);

--- a/build/Cpp/IOHprofiler_run_suite.cpp
+++ b/build/Cpp/IOHprofiler_run_suite.cpp
@@ -23,7 +23,7 @@ int mutation(std::vector<int> &x, double mutation_rate) {
 }
 
 /// This is an (1+1)_EA with static mutation rate = 1/n.
-void evolutionary_algorithm(std::shared_ptr<IOHprofiler_problem<int>> problem, std::shared_ptr<IOHprofiler_csv_logger> logger) {
+void evolutionary_algorithm(std::shared_ptr<IOHprofiler_problem<int>> problem, std::shared_ptr<IOHprofiler_csv_logger<int>> logger) {
   /// Declaration for variables in the algorithm
   std::vector<int> x;
   std::vector<int> x_star;
@@ -66,7 +66,7 @@ void _run_suite() {
   /// If no logger is added, there will be not any output files, but users
   /// can still get fitness values.
   std::vector<int> time_points{1,2,5};
-  std::shared_ptr<IOHprofiler_csv_logger> logger(new IOHprofiler_csv_logger("./","run_suite","EA","EA"));
+  std::shared_ptr<IOHprofiler_csv_logger<int>> logger(new IOHprofiler_csv_logger<int>("./","run_suite","EA","EA"));
   logger->set_complete_flag(true);
   logger->set_interval(2);
   logger->set_time_points(time_points,3);

--- a/src/Problems/Python/IOHprofiler_extern_python.h
+++ b/src/Problems/Python/IOHprofiler_extern_python.h
@@ -1,0 +1,144 @@
+/// \brief Classes for calling problems written in Python.
+///
+/// ...
+///
+/// \author Johann Dreo
+
+#ifndef _IOHPROFILER_EXTERN_PYTHON_H
+#define _IOHPROFILER_EXTERN_PYTHON_H
+
+#include <sstream>
+
+#include "IOHprofiler_problem.h"
+#include "IOHprofiler_extern_python_helper.h"
+
+/** A proxy for problems written in the Python programming language.
+ *
+ * Given a Python module in which exists an instance of a class
+ * honoring the needed interface, this class be be use as a proxy
+ * that will call the Python code of a problem.
+ *
+ * @code
+    IOHprofiler_ExternPythonProblem<int> pypb("mymodule", "myinstance");
+    size_t d = pypb.IOHprofiler_get_number_of_variables();
+    std::vector<int> sol(d,6);
+    double fit = pypb.evaluate(sol);
+    @endcode
+ *
+ * @note Given that this class operates on a class instance
+ * a given Python module may host several problems.
+ * However, you still need to create one C++ class instance
+ * per Python class instance.
+ *
+ * The interface is formed by several member functions,
+ * which should be implemented by the targeted Python class.
+ *
+ * An abstract base class enforcing the default interface
+ * is distributed with IOH in the `ioh.py` file.
+ * Users may inherit from this class to ensure that they
+ * correctly implemented the interface, albeit
+ * this is not mandatory (given that Python does not
+ * enforce type checking).
+ *
+ * Default names of the members can be changed
+ * by modifying the values of the `*api*` parameters
+ * passed to this class' constructor.
+ *
+ * All the `get_*` member functions of the Python interface
+ * just return a parameter.
+ * Only the `call` function takes arguments
+ * (i.e. a candidate solution to the problem).
+ * This class send a call tuple to the Python function,
+ * so that you can either define a fixed number of
+ * explicit variables, either capture the tuple
+ * as a positional argument expansion:
+ * @code
+    # Example for variable dimensions:
+    def call(self, *args ):
+        return sum(*args)
+
+    # Example for fixed dimensions:
+    def call(self, x0, x1, x2):
+        return x0+x1+x2
+ * @endcode
+ */
+template<class InputType>
+class IOHprofiler_ExternPythonProblem : public IOHprofiler_problem<InputType>
+{
+    public:
+        /** The only mandatory arguments are the module and the instance.
+         *
+         * All other arguments defines the API which will be used
+         * to reach the Python code.
+         *
+         * This constructor initialize the Python API
+         * and check if all the necessary member functions
+         * can actually be called.
+         */
+        IOHprofiler_ExternPythonProblem(
+                std::string module_name,
+                std::string instance_name,
+                std::string objective_function_api = "call",
+                std::string instance_api_get = "get_instance",
+                std::string dimension_api_get = "get_number_of_variables",
+                std::string problem_id_api_get = "get_problem_id",
+                std::string lowerbound_api = "get_lowerbound",
+                std::string upperbound_api = "get_upperbound",
+                std::string minimization_api = "get_minimization",
+                std::string name_api = "get_name",
+                std::string type_api = "get_type",
+                std::string number_of_objectives_api = "get_number_of_objectives"
+        );
+
+        // TODO Unused API:
+        // virtual void prepare_problem() { }
+        // virtual void customize_optimal() { }
+
+        /** Actually call the objective function. */
+        virtual double internal_evaluate(const std::vector<InputType> &x);
+
+        /** Deallocate Python variables. */
+        virtual ~IOHprofiler_ExternPythonProblem();
+
+    protected:
+        // This is a lot of boiler plate, but it's better to be eplicit.
+
+        std::string _api_objfunc;
+        PyObject* _py_objfunc;
+
+        std::string _api_instance_get;
+        PyObject* _py_instance_get;
+
+        std::string _api_dimension_get;
+        PyObject* _py_dimension_get;
+
+        std::string _api_problem_id_get;
+        PyObject* _py_problem_id_get;
+
+        std::string _api_lowerbound_get;
+        PyObject* _py_lowerbound_get;
+
+        std::string _api_upperbound_get;
+        PyObject* _py_upperbound_get;
+
+        std::string _api_minimization_get;
+        PyObject* _py_minimization_get;
+
+        std::string _api_name_get;
+        PyObject* _py_name_get;
+
+        std::string _api_type_get;
+        PyObject* _py_type_get;
+
+        std::string _api_number_of_objectives_get;
+        PyObject* _py_number_of_objectives_get;
+
+        const InputType _return_on_error;
+
+        IOHprofiler_ExternPythonHelper<InputType> py;
+};
+
+#include "IOHprofiler_extern_python.hpp"
+
+#endif // _IOHPROFILER_EXTERN_PYTHON_H
+

--- a/src/Problems/Python/IOHprofiler_extern_python.hpp
+++ b/src/Problems/Python/IOHprofiler_extern_python.hpp
@@ -1,0 +1,127 @@
+
+template<class InputType>
+IOHprofiler_ExternPythonProblem<InputType>::IOHprofiler_ExternPythonProblem(
+        std::string module_name,
+        std::string instance_name,
+        std::string objective_function_api,
+        std::string instance_api_get,
+        std::string dimension_api_get,
+        std::string problem_id_api_get,
+        std::string lowerbound_api,
+        std::string upperbound_api,
+        std::string minimization_api,
+        std::string name_api,
+        std::string type_api,
+        std::string number_of_objectives_api
+) :
+    IOHprofiler_problem<InputType>(), // Default instance and dimension
+
+    py(module_name, instance_name),
+
+    _api_objfunc(objective_function_api),
+    _py_objfunc(nullptr),
+
+    _api_instance_get(instance_api_get),
+    _py_instance_get(nullptr),
+
+    _api_dimension_get(dimension_api_get),
+    _py_dimension_get(nullptr),
+
+    _api_problem_id_get(problem_id_api_get),
+    _py_problem_id_get(nullptr),
+
+    _api_lowerbound_get(lowerbound_api),
+    _py_lowerbound_get(nullptr),
+
+    _api_upperbound_get(upperbound_api),
+    _py_upperbound_get(nullptr),
+
+    _api_minimization_get(minimization_api),
+    _py_minimization_get(nullptr),
+
+    _api_name_get(name_api),
+    _py_name_get(nullptr),
+
+    _api_type_get(type_api),
+    _py_type_get(nullptr),
+
+    _api_number_of_objectives_get(number_of_objectives_api),
+    _py_number_of_objectives_get(nullptr),
+
+    _return_on_error(std::numeric_limits<InputType>::infinity())
+{
+
+    // Get and check the necessary interfaces.
+    _py_objfunc          = py.get_callable(_api_objfunc);
+    _py_instance_get     = py.get_callable(_api_instance_get);
+    _py_dimension_get    = py.get_callable(_api_dimension_get);
+    _py_problem_id_get   = py.get_callable(_api_problem_id_get);
+    _py_lowerbound_get   = py.get_callable(_api_lowerbound_get);
+    _py_upperbound_get   = py.get_callable(_api_upperbound_get);
+    _py_minimization_get = py.get_callable(_api_minimization_get);
+    _py_name_get         = py.get_callable(_api_name_get);
+    _py_type_get         = py.get_callable(_api_type_get);
+    _py_number_of_objectives_get
+        = py.get_callable(_api_number_of_objectives_get);
+
+    // Call the Python function to initialize the problem internals.
+    this->IOHprofiler_set_problem_id(
+            py.template call<int>(_py_problem_id_get) );
+
+    this->IOHprofiler_set_instance_id(
+            py.template call<int>(_py_instance_get) );
+
+    this->IOHprofiler_set_number_of_variables(
+            py.template call<int>(_py_dimension_get) );
+
+    if(py.template call<bool>(_py_minimization_get)) {
+        this->IOHprofiler_set_as_minimization();
+    } else {
+        this->IOHprofiler_set_as_maximization();
+    }
+
+    this->IOHprofiler_set_number_of_objectives(
+            py.template call<int>(_py_number_of_objectives_get) );
+
+    this->IOHprofiler_set_lowerbound(
+            py.template call<std::vector<InputType>>(_py_lowerbound_get) );
+
+    this->IOHprofiler_set_upperbound(
+            py.template call<std::vector<InputType>>(_py_upperbound_get) );
+
+    this->IOHprofiler_set_problem_name(
+            py.template call<std::string>(_py_name_get) );
+
+    this->IOHprofiler_set_problem_type(
+            py.template call<std::string>(_py_type_get) );
+
+}
+
+template<class InputType>
+double IOHprofiler_ExternPythonProblem<InputType>::internal_evaluate(const std::vector<InputType> &x)
+{
+    double fitness = py.template call<double>(_py_objfunc, x);
+#ifndef NDEBUG
+        std::ostringstream log_msg;
+        log_msg << "Python objective function returned: " << fitness;
+        IOH_log(log_msg.str());
+#endif
+    return fitness;
+}
+
+template<class InputType>
+IOHprofiler_ExternPythonProblem<InputType>::~IOHprofiler_ExternPythonProblem()
+{
+    Py_DECREF(_py_objfunc);
+    Py_DECREF(_py_objfunc);
+    Py_DECREF(_py_instance_get);
+    Py_DECREF(_py_dimension_get);
+    Py_DECREF(_py_problem_id_get);
+    Py_DECREF(_py_lowerbound_get);
+    Py_DECREF(_py_upperbound_get);
+    Py_DECREF(_py_minimization_get);
+    Py_DECREF(_py_name_get);
+    Py_DECREF(_py_type_get);
+    Py_DECREF(_py_number_of_objectives_get);
+}
+

--- a/src/Problems/Python/IOHprofiler_extern_python_helper.h
+++ b/src/Problems/Python/IOHprofiler_extern_python_helper.h
@@ -1,0 +1,204 @@
+/// \brief Classes for calling Python with templates.
+///
+/// ...
+///
+/// \author Johann Dreo
+
+#ifndef _IOHPROFILER_EXTERN_PYTHON_HELPER_H
+#define _IOHPROFILER_EXTERN_PYTHON_HELPER_H
+
+#include <string>
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/** Helper class which call Python's API without having to bother with types.
+ *
+ * The public interface expose `get_callable` to get
+ * a handle on an instance member function,
+ * and `call` to actually call it with some arguments.
+ *
+ * The class details will take care of converting arguments and return types
+ * from/to Python's data structures.
+ */
+template<class InputType>
+class IOHprofiler_ExternPythonHelper
+{
+    protected:
+        std::string _api_module;
+        std::string _api_instance;
+
+    public:
+        PyObject* module;
+
+        IOHprofiler_ExternPythonHelper(
+                std::string module_name,
+                std::string instance_name
+        );
+
+        ~IOHprofiler_ExternPythonHelper();
+
+        PyObject* get_callable(std::string func_name);
+
+        template<class R>
+        R call(PyObject* py_function);
+
+    protected:
+
+        PyObject* pycall(PyObject* py_callable, PyObject* py_args);
+
+        template<class T>
+        PyObject* as_tuple( const T& x );
+
+        template<class R>
+        R as_num(PyObject* py_value);
+
+        template<class R>
+        R float_as_num(PyObject* py_value);
+
+        template<class R>
+        R long_as_num(PyObject* py_value);
+
+        template<typename T>
+        PyObject* from_num( T x );
+
+        /***************************************************************
+         * Below are implementation of templates specializations.
+         *
+         * Because they are difficult to forward-declare
+         * without dummy helper classes,
+         * the implementation are not in the `*.hpp`.
+         *
+         * You should not need to read them
+         * if you just look for the interface.
+         **************************************************************/
+
+    public:
+        //! Template specializations of call @{
+
+        template<>
+        void call(PyObject* py_function)
+        {
+            PyObject* py_args = PyTuple_New(0);
+            pycall(py_function, py_args);
+            Py_DECREF(py_args);
+        }
+
+        template<>
+        std::vector<InputType> call(PyObject* py_function)
+        {
+            PyObject* py_args = PyTuple_New(0);
+            PyObject* py_res = pycall(py_function, py_args);
+            Py_DECREF(py_args);
+            assert(PyList_Check(py_res));
+            size_t res_len = PyList_Size(py_res);
+            std::vector<InputType> vec;
+            vec.reserve(res_len);
+            for(size_t i=0; i < res_len; ++i) {
+                PyObject* py_item = PyList_GetItem(py_res, i);
+                InputType x = as_num<InputType>(py_item);
+                vec.push_back(x);
+            }
+            Py_DECREF(py_res);
+            return vec;
+        }
+
+        template<>
+        std::string call(PyObject* py_function)
+        {
+            PyObject* py_args = PyTuple_New(0);
+            PyObject* py_res = pycall(py_function, py_args);
+            Py_DECREF(py_args);
+            assert(PyUnicode_Check(py_res));
+            std::string res(PyUnicode_AsUTF8(py_res));
+            Py_DECREF(py_res);
+            return res;
+        }
+
+        template<class R, class T>
+        R call(PyObject* py_function, T args)
+        {
+            PyObject* py_args = as_tuple(args);
+            PyObject* py_res = pycall(py_function, py_args);
+            Py_DECREF(py_args);
+            R res = as_num<R>(py_res);
+            Py_DECREF(py_res);
+            return res;
+        }
+
+        template<class T>
+        void call(PyObject* py_function, T args)
+        {
+            PyObject* py_args = as_tuple(args);
+            pycall(py_function, py_args);
+            Py_DECREF(py_args);
+        }
+
+        //! @}
+
+    protected:
+
+        //! Template specializations of from_num for integer InputType(s). @{
+
+        template<>
+        PyObject* from_num( int x ) {
+            return PyLong_FromLong( x );
+        }
+
+        template<>
+        PyObject* from_num( long x ) {
+            return PyLong_FromLong( x );
+        }
+
+        template<>
+        PyObject* from_num( long long x ) {
+            return PyLong_FromLongLong( x );
+        }
+
+        template<>
+        PyObject* from_num( unsigned long x ) {
+            return PyLong_FromUnsignedLong( x );
+        }
+
+        template<>
+        PyObject* from_num( unsigned long long x ) {
+            return PyLong_FromUnsignedLongLong( x );
+        }
+
+        //! @}
+
+
+        //! Template specialization of as_num @{
+
+        template<>
+        int long_as_num(PyObject* py_value) {
+            return static_cast<int>(PyLong_AsLong(py_value));
+        }
+
+        template<>
+        double long_as_num(PyObject* py_value) {
+            return static_cast<double>(PyLong_AsDouble(py_value));
+        }
+
+        template<>
+        long long long_as_num(PyObject* py_value) {
+            return static_cast<long long>(PyLong_AsLongLong(py_value));
+        }
+
+        template<>
+        unsigned long long_as_num(PyObject* py_value) {
+            return static_cast<unsigned long>(PyLong_AsUnsignedLong(py_value));
+        }
+
+        template<>
+        unsigned long long long_as_num(PyObject* py_value) {
+            return static_cast<unsigned long long>(PyLong_AsUnsignedLongLong(py_value));
+        }
+
+        //! @}
+};
+
+#include "IOHprofiler_extern_python_helper.hpp"
+
+#endif // _IOHPROFILER_EXTERN_PYTHON_HELPER_H
+

--- a/src/Problems/Python/IOHprofiler_extern_python_helper.hpp
+++ b/src/Problems/Python/IOHprofiler_extern_python_helper.hpp
@@ -1,0 +1,189 @@
+
+template<class InputType>
+IOHprofiler_ExternPythonHelper<InputType>::IOHprofiler_ExternPythonHelper(
+        std::string module_name,
+        std::string instance_name
+        )
+    :
+        _api_module(module_name),
+        _api_instance(instance_name)
+{
+    Py_Initialize();
+    PyObject* py_name = PyUnicode_DecodeFSDefault(_api_module.c_str());
+    module = PyImport_Import(py_name);
+    Py_DECREF(py_name);
+
+    if(not module) {
+        PyErr_Print();
+        std::ostringstream msg;
+        msg << "Failed to import the Python module `" << _api_module << "`";
+        IOH_error(msg.str());
+        return;
+
+    } else {
+#ifndef NDEBUG
+        std::ostringstream log_msg;
+        log_msg << "Python module `" << _api_module << "` loaded succesfully";
+        IOH_log(log_msg.str());
+#endif
+    }
+}
+
+template<class InputType>
+IOHprofiler_ExternPythonHelper<InputType>::~IOHprofiler_ExternPythonHelper()
+{
+    Py_DECREF(module);
+}
+
+template<class InputType>
+PyObject* IOHprofiler_ExternPythonHelper<InputType>::pycall(PyObject* py_callable, PyObject* py_args)
+{
+    PyObject* py_result = PyObject_CallObject(py_callable, py_args);
+    Py_DECREF(py_args);
+    if(not py_result) {
+        PyErr_Print();
+        std::ostringstream msg;
+        msg << "Call to Python callable failed";
+        IOH_error(msg.str());
+        return nullptr;
+    }
+    return py_result;
+}
+
+template<class InputType>
+PyObject* IOHprofiler_ExternPythonHelper<InputType>::get_callable(std::string func_name)
+{
+    PyObject* py_inst = PyObject_GetAttrString(module, _api_instance.c_str());
+
+    if(not py_inst) {
+        if(PyErr_Occurred()) {
+            PyErr_Print();
+        }
+        Py_XDECREF(py_inst);
+        std::ostringstream err_msg;
+        err_msg << "Python problem instance not found: `"
+            << _api_instance << "`";
+        IOH_error(err_msg.str()); // FIXME Maybe a local exception would be better.
+        return nullptr; // Useless if IOH_error raise an exception.
+    }
+
+    PyObject* py_func = PyObject_GetAttrString(py_inst, func_name.c_str());
+
+    if(not py_func) {
+        if(PyErr_Occurred()) {
+            PyErr_Print();
+        }
+        Py_XDECREF(py_inst);
+        Py_XDECREF(py_func);
+        std::ostringstream err_msg;
+        err_msg << "Python method not found: `"
+            << _api_instance << "." << func_name << "`";
+        IOH_error(err_msg.str()); // FIXME Maybe a local exception would be better.
+        return nullptr; // Useless if IOH_error raise an exception.
+    }
+
+    if(not PyCallable_Check(py_func)) {
+        if(PyErr_Occurred()) {
+            PyErr_Print();
+        }
+        Py_XDECREF(py_inst);
+        Py_XDECREF(py_func);
+        std::ostringstream err_msg;
+        err_msg << "Python method not callable: `"
+            << _api_instance << "." << func_name << "`";
+        IOH_error(err_msg.str()); // FIXME Maybe a local exception would be better.
+        return nullptr; // Useless if IOH_error raise an exception.
+    }
+
+#ifndef NDEBUG
+    if(py_func and PyCallable_Check(py_func)) {
+        std::ostringstream log_msg;
+        log_msg << "Python object is callable: `"
+                << _api_instance << "." << func_name << "`";
+            ;
+        IOH_log(log_msg.str());
+    }
+#endif
+
+    Py_XDECREF(py_inst);
+    return py_func;
+}
+
+template<class InputType>
+template<class T>
+PyObject* IOHprofiler_ExternPythonHelper<InputType>::as_tuple( const T& x )
+{
+    PyObject* py_args = PyTuple_New( x.size() );
+    for(size_t i = 0; i < x.size(); ++i) {
+        PyObject* py_elem = this->from_num(x[i]);
+        if(not py_elem) {
+            Py_DECREF(py_args);
+            std::ostringstream msg;
+            msg << "Cannot convert argument's element to a Python type `" << x[i] << "`";
+            IOH_error(msg.str());
+            return nullptr;
+        }
+        PyTuple_SetItem(py_args, i, py_elem);
+    }
+    return py_args;
+}
+
+template<class InputType>
+template<class R>
+R IOHprofiler_ExternPythonHelper<InputType>::float_as_num(PyObject* py_value)
+{
+    return static_cast<R>(PyFloat_AsDouble(py_value));
+}
+
+template<class InputType>
+template<class R>
+R IOHprofiler_ExternPythonHelper<InputType>::long_as_num(PyObject* py_value)
+{
+    return static_cast<R>(PyLong_AsLong(py_value));
+}
+
+template<class InputType>
+template<typename T>
+PyObject* IOHprofiler_ExternPythonHelper<InputType>::from_num( T x )
+{
+    return PyFloat_FromDouble( x );
+        }
+
+template<class InputType>
+template<class R>
+R IOHprofiler_ExternPythonHelper<InputType>::as_num(PyObject* py_value)
+{
+    R result;
+    if(PyLong_Check(py_value)) {
+        result = long_as_num<R>(py_value);
+    } else
+    if(PyFloat_Check(py_value)) {
+        result = float_as_num<R>(py_value);
+    } else {
+        std::ostringstream msg;
+        msg << "Cannot convert this Python object type";
+        IOH_error(msg.str());
+        return std::numeric_limits<R>::max();
+    }
+    if(PyErr_Occurred()) {
+        PyErr_Print();
+        std::ostringstream msg;
+        msg << "Python numeric conversion failed";
+        IOH_error(msg.str());
+        return std::numeric_limits<R>::max();
+    }
+    return result;
+}
+
+template<class InputType>
+template<class R>
+R IOHprofiler_ExternPythonHelper<InputType>::call(PyObject* py_function)
+{
+    PyObject* py_args = PyTuple_New(0);
+    PyObject* py_res = pycall(py_function, py_args);
+    Py_DECREF(py_args);
+    R res = as_num<R>(py_res);
+    Py_DECREF(py_res);
+    return res;
+}
+

--- a/src/Problems/Python/ioh.py
+++ b/src/Problems/Python/ioh.py
@@ -1,0 +1,54 @@
+
+import abc
+
+class Problem(object, metaclass=abc.ABCMeta):
+
+    # Objective function
+    @abc.abstractmethod
+    def call(self, *args ):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `call(self,*args):`')
+
+    # i.e. for invariance checking
+    @abc.abstractmethod
+    def get_instance(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_instance(self)`')
+
+    # Dimension
+    @abc.abstractmethod
+    def get_number_of_variables(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_number_of_variables(self)`')
+
+    # Bounds
+
+    @abc.abstractmethod
+    def get_lowerbound(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_lowerbound(self)`')
+
+    @abc.abstractmethod
+    def get_upperbound(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `et_upperbound(self)`')
+
+
+    # Generic information
+
+    @abc.abstractmethod
+    def get_minimization(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_minimization(self)`')
+
+    @abc.abstractmethod
+    def get_problem_id(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_problem_id(self)`')
+
+    @abc.abstractmethod
+    def get_name(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_name(self)`')
+
+    @abc.abstractmethod
+    def get_type(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_type(self)`')
+        return "Test_benchmark"
+
+    @abc.abstractmethod
+    def get_number_of_objectives(self):
+        raise NotImplementedError('Classes inheriting from ioh.Problem must define `get_number_of_objectives(self)`')
+

--- a/src/Suites/IOHprofiler_BBOB_suite.hpp
+++ b/src/Suites/IOHprofiler_BBOB_suite.hpp
@@ -37,6 +37,8 @@
 
 class BBOB_suite : public IOHprofiler_suite<double> {
 public:
+  using InputType = double;
+
   BBOB_suite() {
     std::vector<int> problem_id;
     std::vector<int> instance_id;
@@ -54,6 +56,8 @@ public:
     IOHprofiler_set_suite_dimension(dimension);
     IOHprofiler_set_suite_name("BBOB");
     registerProblem();
+    // Load problem, so that the user don't have to think about it.
+    this->loadProblem();
   };
 
   BBOB_suite(std::vector<int> problem_id, std::vector<int> instance_id, std::vector<int> dimension) {
@@ -80,6 +84,7 @@ public:
     IOHprofiler_set_suite_dimension(dimension);
     IOHprofiler_set_suite_name("BBOB");
     registerProblem();
+    this->loadProblem();
   }
 
   /// \fn void registerProblem()

--- a/src/Suites/IOHprofiler_PBO_suite.hpp
+++ b/src/Suites/IOHprofiler_PBO_suite.hpp
@@ -36,6 +36,8 @@
 
 class PBO_suite : public IOHprofiler_suite<int> {
 public:
+  using InputType = int;
+
   PBO_suite() {
     std::vector<int> problem_id;
     std::vector<int> instance_id;
@@ -47,12 +49,14 @@ public:
       instance_id.push_back(i+1);
     }
     dimension.push_back(100);
-    
+
     IOHprofiler_set_suite_problem_id(problem_id);
     IOHprofiler_set_suite_instance_id(instance_id);
     IOHprofiler_set_suite_dimension(dimension);
     IOHprofiler_set_suite_name("PBO");
-    registerProblem();
+    this->registerProblem();
+    // Load problem, so that the user don't have to think about it.
+    this->loadProblem();
   }
 
   PBO_suite(std::vector<int> problem_id, std::vector<int> instance_id, std::vector<int> dimension) {
@@ -61,7 +65,7 @@ public:
         IOH_error("problem_id " + std::to_string(problem_id[i]) + " is not in PBO_suite");
       }
     }
-    
+
     for (int i = 0; i < instance_id.size(); ++i) {
       if (instance_id[i] < 0 || instance_id[i] > 100) {
         IOH_error("instance_id " + std::to_string(instance_id[i]) + " is not in PBO_suite");
@@ -78,7 +82,8 @@ public:
     IOHprofiler_set_suite_instance_id(instance_id);
     IOHprofiler_set_suite_dimension(dimension);
     IOHprofiler_set_suite_name("PBO");
-    registerProblem();
+    this->registerProblem();
+    this->loadProblem();
   }
 
   /// \fn void registerProblem()
@@ -103,7 +108,7 @@ public:
     registerInFactory<IOHprofiler_problem<int>,LeadingOnes_Ruggedness1> regLeadingOnes_Ruggedness1("LeadingOnes_Ruggedness1");
     registerInFactory<IOHprofiler_problem<int>,LeadingOnes_Ruggedness2> regLeadingOnes_Ruggedness2("LeadingOnes_Ruggedness2");
     registerInFactory<IOHprofiler_problem<int>,LeadingOnes_Ruggedness3> regLeadingOnes_Ruggedness3("LeadingOnes_Ruggedness3");
-    
+
     registerInFactory<IOHprofiler_problem<int>,Linear> regLinear("Linear");
     registerInFactory<IOHprofiler_problem<int>,MIS> regMIS("MIS");
     registerInFactory<IOHprofiler_problem<int>,LABS> regLABS("LABS");
@@ -111,7 +116,7 @@ public:
     registerInFactory<IOHprofiler_problem<int>,Ising_Ring> regIsing_Ring("Ising_Ring");
     registerInFactory<IOHprofiler_problem<int>,Ising_Torus> regIsing_Torus("Ising_Torus");
     registerInFactory<IOHprofiler_problem<int>,Ising_Triangular> regIsing_Triangular("Ising_Triangular");
-  
+
     mapIDTOName(1,"OneMax");
     mapIDTOName(2,"LeadingOnes");
     mapIDTOName(3,"Linear");
@@ -146,3 +151,4 @@ public:
   }
 };
 #endif //_IOHPROFILER_PBO_SUITE_H
+

--- a/src/Template/Experiments/IOHprofiler_experimenter.h
+++ b/src/Template/Experiments/IOHprofiler_experimenter.h
@@ -10,11 +10,11 @@
 
 template <class InputType> class IOHprofiler_experimenter {
 public:
-  typedef void _algorithm(std::shared_ptr<IOHprofiler_problem<InputType> >, std::shared_ptr<IOHprofiler_csv_logger> logger);
+  typedef void _algorithm(std::shared_ptr<IOHprofiler_problem<InputType> >, std::shared_ptr<IOHprofiler_csv_logger<InputType>> logger);
 
   IOHprofiler_experimenter();
   IOHprofiler_experimenter(std::string configFileName, _algorithm *algorithm);
-  IOHprofiler_experimenter(IOHprofiler_suite<InputType> suite, std::shared_ptr<IOHprofiler_csv_logger> csv_logger, _algorithm * algorithm);
+  IOHprofiler_experimenter(IOHprofiler_suite<InputType> suite, std::shared_ptr<IOHprofiler_csv_logger<InputType>> csv_logger, _algorithm * algorithm);
 
   ~IOHprofiler_experimenter(){};
 
@@ -30,7 +30,7 @@ private:
   IOHprofiler_configuration conf;
   std::shared_ptr<IOHprofiler_suite<InputType> > configSuite;
   std::shared_ptr<IOHprofiler_problem<InputType> > current_problem;
-  std::shared_ptr<IOHprofiler_csv_logger> config_csv_logger;
+  std::shared_ptr<IOHprofiler_csv_logger<InputType>> config_csv_logger;
   int independent_runs = 1;
 
   _algorithm *algorithm;

--- a/src/Template/Experiments/IOHprofiler_experimenter.hpp
+++ b/src/Template/Experiments/IOHprofiler_experimenter.hpp
@@ -11,7 +11,7 @@ template <class InputType> IOHprofiler_experimenter<InputType>::IOHprofiler_expe
   configSuite->IOHprofiler_set_suite_dimension(conf.get_dimension());
   configSuite->loadProblem();
 
-  std::shared_ptr<IOHprofiler_csv_logger> logger(new IOHprofiler_csv_logger(conf.get_output_directory(),conf.get_result_folder(),conf.get_algorithm_name(),conf.get_algorithm_info()));
+  std::shared_ptr<IOHprofiler_csv_logger<InputType>> logger(new IOHprofiler_csv_logger<InputType>(conf.get_output_directory(),conf.get_result_folder(),conf.get_algorithm_name(),conf.get_algorithm_info()));
   if (logger == nullptr) {
     IOH_error("Creating logger fails, please check your configuration");
   }
@@ -27,7 +27,7 @@ template <class InputType> IOHprofiler_experimenter<InputType>::IOHprofiler_expe
   this->algorithm = algorithm;
 }
 
-template <class InputType> IOHprofiler_experimenter<InputType>::IOHprofiler_experimenter(IOHprofiler_suite<InputType> suite, std::shared_ptr<IOHprofiler_csv_logger> csv_logger, _algorithm * algorithm) {
+template <class InputType> IOHprofiler_experimenter<InputType>::IOHprofiler_experimenter(IOHprofiler_suite<InputType> suite, std::shared_ptr<IOHprofiler_csv_logger<InputType>> csv_logger, _algorithm * algorithm) {
   configSuite = suite;
   config_csv_logger = csv_logger;
   this->algorithm = algorithm;

--- a/src/Template/IOHprofiler_class_generator.hpp
+++ b/src/Template/IOHprofiler_class_generator.hpp
@@ -17,6 +17,8 @@ template <class manufacturedObj> std::shared_ptr<manufacturedObj> genericGenerat
   typename FN_registry::const_iterator regEntry = registry.find(className);
   if (regEntry != registry.end()) {
     return (*regEntry).second();
+  } else {
+    IOH_error("Object unknown in the registry");
   }
   return ret;
 }

--- a/src/Template/IOHprofiler_common.cpp
+++ b/src/Template/IOHprofiler_common.cpp
@@ -1,24 +1,20 @@
-#ifndef _IOHPROFILER_COMMON_CPP
-#define _IOHPROFILER_COMMON_CPP
-
 #include "IOHprofiler_common.h"
 
 /// \todo Add specific code for errors.
 void IOH_error(std::string error_info) {
-  std::cerr << "IOH_ERROR_INFO : " << error_info << std::endl;
-  exit(1);
+  std::cerr << "IOH_ERROR_INFO: " << error_info << std::endl;
+  throw std::runtime_error(error_info);
 }
 
 void IOH_warning(std::string warning_info) {
-  std::cout << "IOH_WARNING_INFO : " << warning_info << std::endl;
+  std::cerr << "IOH_WARNING_INFO: " << warning_info << std::endl;
 }
 
 void IOH_log(std::string log_info) {
-  std::cout << "IOH_LOG_INFO : " << log_info << std::endl;
+  std::clog << "IOH_LOG_INFO: " << log_info << std::endl;
 }
 
 void IOH_log(std::string log_info, std::ofstream &log_stream) {
-  log_stream << "IOH_LOG_INFO : " << log_info << std::endl;
+  log_stream << "IOH_LOG_INFO: " << log_info << std::endl;
 }
 
-#endif //IOHPROFILER_COMMON_CPP

--- a/src/Template/IOHprofiler_common.h
+++ b/src/Template/IOHprofiler_common.h
@@ -33,12 +33,9 @@
 /// < Default dimension
 #define DEFAULT_DIMENSION 4
 
-<<<<<<< HEAD
 /// < Max buffer size
 #define MAX_BUFFER_SIZE 65534
 
-=======
->>>>>>> 75c3f3b... style: optim. type in enum + use numeric_limits
 enum IOH_optimization_type {Minimization=0, Maximization=1};
 
 void IOH_error(std::string error_info);

--- a/src/Template/IOHprofiler_common.h
+++ b/src/Template/IOHprofiler_common.h
@@ -33,9 +33,12 @@
 /// < Default dimension
 #define DEFAULT_DIMENSION 4
 
+<<<<<<< HEAD
 /// < Max buffer size
 #define MAX_BUFFER_SIZE 65534
 
+=======
+>>>>>>> 75c3f3b... style: optim. type in enum + use numeric_limits
 enum IOH_optimization_type {Minimization=0, Maximization=1};
 
 void IOH_error(std::string error_info);

--- a/src/Template/IOHprofiler_observer.h
+++ b/src/Template/IOHprofiler_observer.h
@@ -6,6 +6,7 @@
 #define _IOHPROFILER_OBSERVER_H
 
 #include "IOHprofiler_common.h"
+#include "IOHprofiler_suite.h"
 #include "IOHprofiler_problem.h"
 /// \brief A class of methods of setting triggers recording evaluations.
 ///
@@ -14,8 +15,21 @@
 ///   2. Recording complete evaluations.
 ///   3. Recording evaluations as the best found solution is updated.
 ///   4. Recording evaluations at pre-defined points or/and with a static number for each exponential bucket.
+template<class T>
 class IOHprofiler_observer {
 public:
+
+  /** API for subclasses @{ */
+  using InputType = T;
+
+  virtual void track_problem(const IOHprofiler_problem<InputType> & problem) = 0;
+
+  virtual void track_suite(const IOHprofiler_suite<T>& suite) = 0;
+
+  virtual void do_log(const std::vector<double> &log_info) = 0;
+  /** }@ */
+
+
   IOHprofiler_observer() :
     observer_interval(0),
     observer_complete_flag(false),
@@ -28,17 +42,19 @@ public:
     evaluations_value2(1),
     evaluations_expi(0),
     observer_time_points_exp_base2(10){}
+
   virtual ~IOHprofiler_observer() {};
 
   IOHprofiler_observer(const IOHprofiler_observer &) = delete;
+
   IOHprofiler_observer &operator = (const IOHprofiler_observer&) = delete;
-  
+
   void set_complete_flag(bool complete_flag);
 
   bool complete_status() const;
 
   bool complete_trigger() const;
-  
+
   void set_interval(int interval);
 
   bool interval_status() const;
@@ -50,7 +66,7 @@ public:
   bool update_trigger(double fitness, IOH_optimization_type optimization_type);
 
   bool update_status() const;
-  
+
   void set_time_points(const std::vector<int> & time_points, const int number_of_evaluations, const int time_points_exp_base1 = 10, const int time_points_exp_base2 = 10);
 
   bool time_points_status() const;
@@ -59,18 +75,14 @@ public:
 
   void reset_observer(const IOH_optimization_type optimization_type);
 
-  virtual void do_log(const std::vector<double> &log_info) {}
-
-  virtual void track_problem(const IOHprofiler_problem<int> & problem) {}
-  
-  virtual void track_problem(const IOHprofiler_problem<double> & problem) {}
+  //
   /// \todo Adding virtual functions for more IuputType IOHprofiler_problem.
 
 private:
   int observer_interval; /// < variable for recording by a static interval.
   bool observer_complete_flag; /// < variable for recording complete optimization process. 
   bool observer_update_flag; /// < variable for recording when a better solution is found.
- 
+
   std::vector<int> observer_time_points; /// < variables for recording at pre-defined points.
   size_t evaluations_value1; /// < intermediate variables for calculating points with 'observer_time_points'.
   size_t time_points_index; /// < intermediate variables for calculating points with 'observer_time_points'.
@@ -81,9 +93,11 @@ private:
   size_t evaluations_value2; /// < intermediate variables for calculating points with 'observer_number_of_evaluations'.
   int evaluations_expi; /// < intermediate variables for calculating points with 'observer_number_of_evaluations'.
   int observer_time_points_exp_base2;
-  
+
   /// \todo Currently this is only for single objective optimization.
   double current_best_fitness;
 };
+
+#include "IOHprofiler_observer.hpp"
 
 #endif // _IOHPROFILER_OBSERVER_H

--- a/src/Template/IOHprofiler_observer.hpp
+++ b/src/Template/IOHprofiler_observer.hpp
@@ -5,23 +5,23 @@
 
 #include "IOHprofiler_observer.h"
 
-void IOHprofiler_observer::set_complete_flag(bool complete_flag) {
+template<class T> void IOHprofiler_observer<T>::set_complete_flag(bool complete_flag) {
   this->observer_complete_flag = complete_flag;
 }
 
-bool IOHprofiler_observer::complete_status() const {
+template<class T> bool IOHprofiler_observer<T>::complete_status() const {
   return observer_complete_flag;
 }
 
-bool IOHprofiler_observer::complete_trigger() const {
+template<class T> bool IOHprofiler_observer<T>::complete_trigger() const {
   return observer_complete_flag;
 }
 
-void IOHprofiler_observer::set_interval(int interval) {
+template<class T> void IOHprofiler_observer<T>::set_interval(int interval) {
   this->observer_interval = interval;  
 }
 
-bool IOHprofiler_observer::interval_status() const {
+template<class T> bool IOHprofiler_observer<T>::interval_status() const {
   if (observer_interval == 0) {
     return false;
   } else {
@@ -29,7 +29,7 @@ bool IOHprofiler_observer::interval_status() const {
   }
 }
 
-bool IOHprofiler_observer::interval_trigger(size_t evaluations) const {
+template<class T> bool IOHprofiler_observer<T>::interval_trigger(size_t evaluations) const {
   if (observer_interval == 0) {
     return false;
   }
@@ -40,15 +40,15 @@ bool IOHprofiler_observer::interval_trigger(size_t evaluations) const {
   }
 }
 
-void IOHprofiler_observer::set_update_flag(bool update_flag) {
+template<class T> void IOHprofiler_observer<T>::set_update_flag(bool update_flag) {
   this->observer_update_flag = update_flag;
 }
 
-bool IOHprofiler_observer::update_status() const {
+template<class T> bool IOHprofiler_observer<T>::update_status() const {
   return observer_update_flag;
 }
 
-bool IOHprofiler_observer::update_trigger(double fitness, IOH_optimization_type optimization_type) {
+template<class T> bool IOHprofiler_observer<T>::update_trigger(double fitness, IOH_optimization_type optimization_type) {
   if (observer_update_flag == false) {
     return false;
   }
@@ -61,14 +61,14 @@ bool IOHprofiler_observer::update_trigger(double fitness, IOH_optimization_type 
   return false;
 }
 
-void IOHprofiler_observer::set_time_points(const std::vector<int> & time_points, const int number_of_evaluations, const int time_points_exp_base1, const int time_points_exp_base2) {
+template<class T> void IOHprofiler_observer<T>::set_time_points(const std::vector<int> & time_points, const int number_of_evaluations, const int time_points_exp_base1, const int time_points_exp_base2) {
   this->observer_time_points = time_points;
   this->observer_number_of_evaluations = number_of_evaluations;
   this->observer_time_points_exp_base1 = time_points_exp_base1;
   this->observer_time_points_exp_base2 = time_points_exp_base2;
 }
 
-bool IOHprofiler_observer::time_points_status() const {
+template<class T> bool IOHprofiler_observer<T>::time_points_status() const {
   if (this->observer_time_points.size() > 0) {
     if(!(this->observer_time_points.size() == 1 && this->observer_time_points[0] == 0)) {
       return true;
@@ -80,7 +80,7 @@ bool IOHprofiler_observer::time_points_status() const {
   return false;
 }
 
-bool IOHprofiler_observer::time_points_trigger(size_t evaluations) {
+template<class T> bool IOHprofiler_observer<T>::time_points_trigger(size_t evaluations) {
   if (this->time_points_status() == false) {
     return false;
   }
@@ -120,7 +120,7 @@ bool IOHprofiler_observer::time_points_trigger(size_t evaluations) {
   return result;
 }
 
-void IOHprofiler_observer::reset_observer(const IOH_optimization_type optimization_type) {
+template<class T> void IOHprofiler_observer<T>::reset_observer(const IOH_optimization_type optimization_type) {
   if (optimization_type == IOH_optimization_type::Maximization) {
     this->current_best_fitness = std::numeric_limits<double>::lowest();
   } else {

--- a/src/Template/IOHprofiler_problem.h
+++ b/src/Template/IOHprofiler_problem.h
@@ -34,6 +34,8 @@ public:
     lowerbound(std::vector<InputType> (number_of_variables) ), 
     upperbound(std::vector<InputType> (number_of_variables) ),
     optimal(std::vector<double>(number_of_objectives) ),
+    raw_objectives(std::vector<double>(number_of_objectives)),
+    transformed_objectives(std::vector<double>(number_of_objectives)),
     optimalFound(false),
     evaluations(0),
     best_so_far_raw_objectives(std::vector<double>(number_of_objectives) ),

--- a/src/Template/IOHprofiler_problem.hpp
+++ b/src/Template/IOHprofiler_problem.hpp
@@ -1,5 +1,8 @@
 
 template <class InputType> double IOHprofiler_problem<InputType>::evaluate(std::vector<InputType> x) {
+  assert(this->raw_objectives.size() >= 1);
+  assert(this->transformed_objectives.size() == this->raw_objectives.size());
+
   ++this->evaluations;
 
   if(x.size() != this->number_of_variables) {
@@ -15,7 +18,8 @@ template <class InputType> double IOHprofiler_problem<InputType>::evaluate(std::
   }
 
   transformation.variables_transformation(x,this->problem_id,this->instance_id,this->problem_type);
-  this->raw_objectives[0] = internal_evaluate(x);
+
+  this->raw_objectives[0] = this->internal_evaluate(x);
 
   this->transformed_objectives[0] = this->raw_objectives[0];
 

--- a/src/Template/IOHprofiler_problem.hpp
+++ b/src/Template/IOHprofiler_problem.hpp
@@ -1,3 +1,4 @@
+
 template <class InputType> double IOHprofiler_problem<InputType>::evaluate(std::vector<InputType> x) {
   ++this->evaluations;
 
@@ -15,7 +16,7 @@ template <class InputType> double IOHprofiler_problem<InputType>::evaluate(std::
 
   transformation.variables_transformation(x,this->problem_id,this->instance_id,this->problem_type);
   this->raw_objectives[0] = internal_evaluate(x);
-  
+
   this->transformed_objectives[0] = this->raw_objectives[0];
 
   transformation.objectives_transformation(x,this->transformed_objectives,this->problem_id,this->instance_id,this->problem_type);

--- a/src/Template/IOHprofiler_suite.hpp
+++ b/src/Template/IOHprofiler_suite.hpp
@@ -15,6 +15,7 @@ template <class InputType> void IOHprofiler_suite<InputType>::loadProblem() {
       }
     }
   }
+  assert(this->size_of_problem_list == this->size());
   this->get_problem_flag = false;
   this->load_problem_flag = true;
 }
@@ -59,6 +60,7 @@ template <class InputType> std::shared_ptr<IOHprofiler_problem<InputType> > IOHp
 
 template <class InputType> std::shared_ptr<IOHprofiler_problem<InputType> > IOHprofiler_suite<InputType>::get_problem(std::string problem_name, int instance, int dimension) {
   Problem_ptr p = genericGenerator<IOHprofiler_problem<InputType> >::instance().create(problem_name);
+  assert(p != nullptr);
   p->reset_problem();
   p->IOHprofiler_set_problem_id(this->problem_name_id_map[problem_name]);
   p->IOHprofiler_set_instance_id(instance);
@@ -68,6 +70,7 @@ template <class InputType> std::shared_ptr<IOHprofiler_problem<InputType> > IOHp
 
 template <class InputType> std::shared_ptr<IOHprofiler_problem<InputType> > IOHprofiler_suite<InputType>::get_problem(int problem_id, int instance, int dimension) {
   Problem_ptr p = genericGenerator<IOHprofiler_problem<InputType> >::instance().create(this->problem_id_name_map[problem_id]);
+  assert(p != nullptr);
   p->reset_problem();
   p->IOHprofiler_set_problem_id(problem_id);
   p->IOHprofiler_set_instance_id(instance);

--- a/src/Template/Loggers/IOHprofiler_csv_logger.h
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.h
@@ -12,24 +12,25 @@
 ///
 /// To activate logger functions as evaluating problems,  a 'logger' must be added to
 /// IOHprofiler_problem by the statement 'problem.add_logger(logger)'.
-class IOHprofiler_csv_logger : public IOHprofiler_observer {
+template<class T>
+class IOHprofiler_csv_logger : public IOHprofiler_observer<T> {
 public:
 
   IOHprofiler_csv_logger();
 
   IOHprofiler_csv_logger(std::string directory, std::string folder_name,
                          std::string alg_name, std::string alg_info);
-  
+
   ~IOHprofiler_csv_logger();
 
   bool folder_exist(std::string folder_name);
 
   void activate_logger();
-  
+
   void clear_logger();
-  
+
   void add_dynamic_attribute(const std::vector<std::shared_ptr<double> > &attributes);
-  
+
   void add_dynamic_attribute(const std::vector<std::shared_ptr<double> > &attributes, const std::vector<std::string> &attributes_name);
 
   void add_attribute(std::string, int);
@@ -46,32 +47,34 @@ public:
   ///
   /// This function is to be invoked by IOHprofiler_problem class.
   /// To update info of current working problem, and to write headline in corresponding files.
-
   void track_problem(const int problem_id, const int dimension, const int instance, const std::string problem_name, const IOH_optimization_type maximization_minimization_flag);
-  
-  
-  void track_problem(const IOHprofiler_problem<int> & problem);
-  
-  void track_problem(const IOHprofiler_problem<double> & problem);
+
+
+  void track_problem(const IOHprofiler_problem<T> & problem);
 
   void track_suite(std::string suite_name);
 
+  void track_suite(const IOHprofiler_suite<T>& suite)
+  {
+    this->track_suite(suite.IOHprofiler_suite_get_suite_name());
+  }
+
   void openInfo(int problem_id, int dimension, std::string problem_name);
-  
+
   void write_info(int instance, double best_y, double best_transformed_y, int evaluations, 
                   double last_y, double last_transformed_y, int last_evaluations);
 
   void write_line(const size_t evaluations, const double y, const double best_so_far_y,
                  const double transformed_y, const double best_so_far_transformed_y);
-                 
+
   void do_log(const std::vector<double> &log_info);
 
   void write_line(const std::vector<double> &log_info);
-  
+
   void update_logger_info(size_t optimal_evaluations, double y, double transformed_y);
-  
+
   void set_parameters(const std::vector<std::shared_ptr<double> > &parameters);
-  
+
   void set_parameters(const std::vector<std::shared_ptr<double> > &parameters, const std::vector<std::string> &parameters_name);
 
 private:
@@ -120,7 +123,7 @@ private:
 
   int last_dimension = 0;
   int last_problem_id = -1;
-  
+
   /// \fn std::string IOHprofiler_experiment_folder_name()
   /// \brief return an available name of folder to be created.
   ///
@@ -132,11 +135,18 @@ private:
   ///     expected directory will be renamed as 'test-1', 'test-2', ... 
   ///     until there is no such a folder or file. 
   std::string IOHprofiler_experiment_folder_name();
-  
-  int IOHprofiler_create_folder(const std::string path);
+
+  /// Create the log folder.
+  ///
+  /// @warning If you pass a path composed of several nested directories
+  ///          but the first parents directories do not exists,
+  ///          this function will not create them
+  ///          and will raise an ENOENT (-2) error with the message
+  ///          "No such file or directory".
+  bool IOHprofiler_create_folder(const std::string path);
 
   bool header_flag; /// < parameters to track if the header line is logged.
-  
+
   /// \fn write_header()
   ///
   /// This function is to be invoked before recoring evaluations (if evaluations == 0).
@@ -153,5 +163,7 @@ private:
   // std::shared_ptr<IOHprofiler_problem<int> >  tracked_problem_int;
   // std::shared_ptr<IOHprofiler_problem<double> > tracked_problem_double;
 };
+
+#include "IOHprofiler_csv_logger.hpp"
 
 #endif //_IOHPROFILER_CSV_LOGGER_H

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -1,0 +1,295 @@
+/// \file IOHprofiler_ecdf_logger.h
+/// \brief Header file for classes: IOHprofiler_ecdf_logger, IOHprofiler_Range*, IOHprofiler_ecdf_*.
+///
+/// \author Johann Dreo
+#ifndef _IOHPROFILER_ECDF_LOGGER_H_
+#define _IOHPROFILER_ECDF_LOGGER_H_
+
+#include <iostream>
+#include <sstream>
+
+#include "IOHprofiler_observer.h"
+#include "IOHprofiler_common.h"
+#include "IOHprofiler_problem.h"
+
+/** Interface for classes that computes indices from ranges.
+ *
+ * The idea is to input [min,max] and the discretization size
+ * and to compute the position in [0,size] of any value in [min,max].
+ *
+ * Used in IOHprofiler_ecdf_logger.
+ */
+template<class R>
+class IOHprofiler_Range
+{
+    public:
+        IOHprofiler_Range(R amin, R amax, size_t asize);
+        R min() const;
+        R max() const;
+        size_t size() const;
+        R length() const;
+        R step() const;
+
+        //! Main interface.
+        virtual size_t index( double x ) = 0;
+
+    protected:
+        R _min;
+        R _max;
+        size_t _size;
+};
+
+/** Linear range.
+ */
+template<class R>
+class IOHprofiler_RangeLinear : public IOHprofiler_Range<R>
+{
+    public:
+        IOHprofiler_RangeLinear(R min, R max, size_t size);
+
+        virtual size_t index( double x );
+};
+
+/** Logarithmic (base 10) range.
+ */
+template<class R>
+class IOHprofiler_RangeLog : public IOHprofiler_Range<R>
+{
+    public:
+        IOHprofiler_RangeLog(R min, R max, size_t size);
+
+        virtual size_t index( double x );
+};
+
+/** Type used to store a single run attainment bi-dimensional function.
+ *
+ * First dimension is error targets,
+ * second dimension function evaluations targets.
+ *
+ * @note One expect to have a lot of those matrix in a real-life setting,
+ * and the more general case is to have objective-function bounded computation times.
+ * It is thus chosen to reduce the memory footprint, using the infamous bool vector specialization
+ * instead of the (supposedly) faster vector of char.
+ */
+using IOHprofiler_AttainMat =
+    std::vector<       // error targets
+        std::vector<   // function evaluations
+            bool >>;   // occurence count
+
+/** Print an attainment matrix on an output stream.
+ */
+std::ostream& operator<<(std::ostream& out, const IOHprofiler_AttainMat& mat);
+
+/** Type used to store all bi-dimensional attainment functions.
+ *
+ * First dimension is the problem id,
+ * second dimension is the dimension id,
+ * last dimension is the instance id.
+ * Every item is an IOHprofiler_AttainMat.
+ */
+using IOHprofiler_AttainSuite =
+    std::map< size_t,         // problem
+        std::map< size_t,     // dim
+            std::map< size_t, // instance
+                 IOHprofiler_AttainMat >>>; // ECDF
+
+/** An observer which stores bi-dimensional error/evaluations discretized attainment matrices.
+ *
+ * A matrix is stored for each triplet (problem,dimension,instance),
+ * everything being identified by its index.
+ * Attainment matrices are boolean 2D tables, in which a 1 indicates that
+ * an error target (row index) have been attained at an evaluation target (column index).
+ *
+ * The whole set of matrices can be accessed by the `get` accessor.
+ * A single one can be accessed by the `at` accessor.
+ * Ranges can be get back by `*_range` accessors,
+ * which give access to the corresponding `min` and `max` functions (@see IOHprofiler_Range).
+ *
+ * Example:
+ * @code
+    using Logger = IOHprofiler_ecdf_logger<BBOB_suite::Input_type>;
+    BBOB_suite bench({1,2},{1,2},{2,10});
+    Logger logger(0,4e7,0, 0,100,20);
+
+    BBOB_suite::Problem_ptr pb;
+    while(pb = bench.get_next_problem()) {
+        logger.target_problem(*pb);
+        // Make a `sol`
+        for(size_t i=0; i<100; ++i) { // 100 evaluations
+            double f = pb->evaluate(sol);
+            logger.write_line(pb->loggerInfo());
+        }
+    }
+    std::clog << logger.at(1,2,2) << std::endl;
+ * @endcode
+ */
+template<class T>
+class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
+{
+    protected:
+        /** Internal types  @{ */
+        /** Keep essential metadata about the problem. */
+        struct Problem {
+            int pb;
+            int dim;
+            int ins;
+            std::vector<double> opt;
+            IOH_optimization_type maxmin;
+        };
+        /** @} */
+
+    public:
+        /** Scalar type of the solutions encoding the underlying (suite of) problems. */
+        using InputType = typename IOHprofiler_observer<T>::InputType;
+
+    public:
+
+        /** Simple constructor that defaults to log-log scale.
+         */
+        IOHprofiler_ecdf_logger(
+                const double error_min, const double error_max, const size_t error_buckets,
+                const size_t evals_min, const size_t evals_max, const size_t evals_buckets
+            );
+
+        /** Complete constructor, with which you can define linear or semi-log scale.
+         *
+         * @see IOHprofiler_RangeLinear
+         */
+        IOHprofiler_ecdf_logger(
+                IOHprofiler_Range<double>& error_buckets,
+                IOHprofiler_Range<size_t>& evals_buckets
+            );
+
+    public:
+        /** Observer interface  @{ */
+
+        //! Not used, but part of the interface.
+        void activate_logger();
+
+        //! Not used, but part of the interface.
+        void track_suite(const IOHprofiler_suite<T>&);
+
+        //! Initialize on the given problem.
+        void track_problem(const IOHprofiler_problem<T> & pb);
+
+        /** Actually store information about the last evaluation.
+         *
+         * Should be called right after IOHprofiler_problem::evaluate,
+         * passing IOHprofiler_problem::loggerInfo().
+         */
+        void do_log(const std::vector<double>& infos);
+
+        /** @} observer interface */
+
+    public:
+        /** Accessors @{ */
+
+        /** Access all the data computed by this observer. */
+        const IOHprofiler_AttainSuite& data();
+
+        /** Access a single attainment matrix.
+         *
+         * @note Use the same indices order than IOHprofiler_problem.
+         *
+         * First index: problem id,
+         * second index: instance id,
+         * third index: dimension id.
+         */
+        const IOHprofiler_AttainMat& at(size_t problem_id, size_t instance_id, size_t dim_id) const;
+
+        /** Returns the size of the computed data, in its internal order.
+         *
+         * @note: the order of the indices is not the one used by IOHprofiler_logger interface!
+         *
+         * First index: number of problems,
+         * second index: number of dimensions,
+         * third index: number of instances.
+         */
+        std::tuple<size_t, size_t, size_t> size();
+
+        /** Accessor to the range used for error targets in this logger instance. */
+        IOHprofiler_Range<double> error_range();
+
+        /** Accessor to the range used for evaluations targets in this logger instance. */
+        IOHprofiler_Range<size_t> eval_range();
+
+        /** @} */
+
+    protected:
+        /** Internal methods  @{ */
+
+        //! Clear all previously computed data structure.
+        void reset();
+
+        //! Create maps and matrix for this problem.
+        void init_ecdf( const Problem& cur );
+
+        //! Returns the current attainment matrix.
+        IOHprofiler_AttainMat& current_ecdf();
+
+        /** Fill up the upper/upper quadrant of the attainment matrix with ones.
+         *
+         * Take care of not losing time overwriting existing quadrants.
+         */
+        void fill_up( size_t i_error, size_t j_evals);
+
+        /** @} */
+
+    protected:
+        /** Internal members  @{ */
+
+        //! Range for the errors axis.
+        IOHprofiler_Range<double>& _range_error;
+
+        //! Range for the evaluations axis.
+        IOHprofiler_Range<size_t>& _range_evals;
+
+        //! Currently targeted problem metadata.
+        Problem _current;
+
+        //! An attainment matrix filled with zeros, copied for each new problem/instance/dim.
+        IOHprofiler_AttainMat _empty;
+
+        //! The whole main data structure.
+        IOHprofiler_AttainSuite _ecdf_suite;
+
+    private:
+        //! Default range for errors is logarithmic.
+        IOHprofiler_RangeLog<double> _default_range_error;
+
+        //! Default range for evaluations is logarithmic.
+        IOHprofiler_RangeLog<size_t> _default_range_evals;
+
+        /** @} */
+};
+
+/** An interface for classes that computes statistics
+ * over the IOHprofiler_AttainSuite computed by an IOHprofiler_ecdf_logger.
+ *
+ * The template indicates the return type of the functor interface.
+ */
+template<class T>
+class IOHprofiler_ecdf_stat
+{
+    public:
+        using Type = T;
+        virtual T operator()(const IOHprofiler_AttainSuite& attainment) = 0;
+};
+
+/** Computes the sum of all elements of an IOHprofiler_AttainSuite data structure.
+ *
+ * @code
+    IOHprofiler_ecdf_sum sum;
+    size_t s = sum(logger.get());
+ * @endcode
+ */
+class IOHprofiler_ecdf_sum : public IOHprofiler_ecdf_stat<size_t>
+{
+    public:
+        size_t operator()(const IOHprofiler_AttainSuite& attainment);
+};
+
+#include "IOHprofiler_ecdf_logger.hpp"
+
+#endif // _IOHPROFILER_ECDF_LOGGER_H_
+

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
@@ -1,0 +1,293 @@
+/// \file IOHprofiler_ecdf_logger.h
+/// \brief Header file for class IOHprofiler_ecdf_logger.
+///
+///
+/// \author Johann Dreo
+/// \date 2020-02-04
+
+/***** IOHprofiler_Range ****/
+
+template<class R>
+IOHprofiler_Range<R>::IOHprofiler_Range(R amin, R amax, size_t asize) :
+    _min(amin),
+    _max(amax),
+    _size(asize)
+{ }
+
+template<class R>
+R IOHprofiler_Range<R>::min() const {return _min;}
+
+template<class R>
+R IOHprofiler_Range<R>::max() const {return _max;}
+
+template<class R>
+size_t IOHprofiler_Range<R>::size() const {return _size;}
+
+template<class R>
+R IOHprofiler_Range<R>::length() const {return _max - _min;}
+
+template<class R>
+R IOHprofiler_Range<R>::step() const {return length()/_size;}
+
+
+/***** IOHprofiler_RangeLinear ****/
+
+template<class R>
+IOHprofiler_RangeLinear<R>::IOHprofiler_RangeLinear(R min, R max, size_t size) :
+    IOHprofiler_Range<R>(min,max,size)
+{ }
+
+template<class R>
+size_t IOHprofiler_RangeLinear<R>::index( double x )
+{
+    return std::floor( (x - this->min()) / (this->length()) * this->size() );
+}
+
+
+/***** IOHprofiler_RangeLog ****/
+
+template<class R>
+IOHprofiler_RangeLog<R>::IOHprofiler_RangeLog(R min, R max, size_t size) :
+    IOHprofiler_Range<R>(min,max,size)
+{ }
+
+template<class R>
+size_t IOHprofiler_RangeLog<R>::index( double x )
+{
+    return std::floor( std::log10(1+(x-this->min())) / std::log10(1+this->length()) * this->size() );
+}
+
+
+/***** IOHprofiler_AttainMat *****/
+
+std::ostream& operator<<(std::ostream& out, const IOHprofiler_AttainMat& mat)
+{
+    // Just in case one store anything else than 0/1 some day.
+    size_t ndigits = 1;
+    if(mat.back().back() > 0) {
+        ndigits = 1+std::floor(std::log10(mat.back().back()));
+    }
+    out.precision(ndigits);
+    for(size_t i=0; i < mat.size(); ++i) {
+        for(size_t j = 0; j < mat[i].size(); ++j) {
+            out << std::fixed << mat[i][j] << " ";
+        }
+        out << std::endl;
+    }
+    return out;
+}
+
+
+/***** IOHprofiler_ecdf_logger *****/
+
+template<class T>
+IOHprofiler_ecdf_logger<T>::IOHprofiler_ecdf_logger(
+        const double error_min, const double error_max, const size_t error_buckets,
+        const size_t evals_min, const size_t evals_max, const size_t evals_buckets
+    ) :
+        _default_range_error(error_min, error_max, error_buckets),
+        _default_range_evals(evals_min, evals_max, evals_buckets),
+        _range_error(_default_range_error),
+        _range_evals(_default_range_evals),
+        _empty( error_buckets,
+            std::vector<bool>( evals_buckets,
+                0))
+{ }
+
+template<class T>
+IOHprofiler_ecdf_logger<T>::IOHprofiler_ecdf_logger(
+        IOHprofiler_Range<double>& error_buckets,
+        IOHprofiler_Range<size_t>& evals_buckets
+    ) :
+        _default_range_error(0,1,1),
+        _default_range_evals(0,1,1),
+        _range_error(error_buckets),
+        _range_evals(evals_buckets),
+        _empty( error_buckets.size(),
+            std::vector<bool>( evals_buckets.size(),
+                0))
+{ }
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::activate_logger()
+{
+    // pass
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::track_suite(const IOHprofiler_suite<T>&)
+{
+    reset();
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::track_problem(const IOHprofiler_problem<T> & pb)
+{
+    _current.pb     = pb.IOHprofiler_get_problem_id();
+    _current.dim    = pb.IOHprofiler_get_number_of_variables();
+    _current.ins    = pb.IOHprofiler_get_instance_id();
+    _current.maxmin = pb.IOHprofiler_get_optimization_type();
+    _current.opt    = pb.IOHprofiler_get_optimal();
+    // mono-objective only
+    assert(_current.opt.size() == 1);
+    init_ecdf(_current);
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::do_log(const std::vector<double>& infos)
+{
+    /* loggerInfo:
+     *   evaluations,
+     *   raw_objectives,
+     *   best_so_far_raw_objectives
+     *   transformed_objective
+     *   best_so_far_transformed_objectives
+     */
+
+    // TODO make a struct for loggerInfo?
+    double evals = infos[0];
+    double err = std::abs(_current.opt[0] - infos[4]);
+
+    // If this target is worst than the domain.
+    if( evals > _range_evals.max() or err > _range_error.max() ) {
+        // Discard it.
+        std::clog << "WARNING: target out of domain. Error:" << err << ", evaluations:" << evals << std::endl;
+        return;
+
+    } else {
+        size_t i_error;
+        size_t j_evals;
+
+        // If the target is in domain
+        if(_range_error.min() <= err and err <= _range_error.max()) {
+            i_error = _range_error.index(err);
+
+        // If the target is better than the domain
+        } else if( err < _range_error.min() ) {
+            i_error = 0;
+        }
+
+        if(_range_evals.min() <= evals and evals <= _range_evals.max()) {
+            j_evals = _range_evals.index(evals);
+
+        } else if( evals < _range_evals.min() ) {
+            j_evals = 0;
+        }
+
+        // Fill up the upper/upper quadrant of the attainment matrix with ones.
+        fill_up(i_error, j_evals);
+    }
+}
+
+template<class T>
+const IOHprofiler_AttainSuite& IOHprofiler_ecdf_logger<T>::data()
+{
+    return _ecdf_suite;
+}
+
+template<class T>
+const IOHprofiler_AttainMat& IOHprofiler_ecdf_logger<T>::at(size_t problem_id, size_t instance_id, size_t dim_id) const
+{
+    assert(_ecdf_suite.count(problem_id) != 0);
+    assert(_ecdf_suite.at(problem_id).count(dim_id) != 0);
+    assert(_ecdf_suite.at(problem_id).at(dim_id).count(instance_id) != 0);
+    return _ecdf_suite.at(problem_id).at(dim_id).at(instance_id);
+}
+
+template<class T>
+std::tuple<size_t, size_t, size_t> IOHprofiler_ecdf_logger<T>::size()
+{
+    return std::make_tuple(
+        _ecdf_suite.size(), // problems
+        _ecdf_suite.begin()->second.size(), // dimensions
+        _ecdf_suite.begin()->second.begin()->second.size() // instances
+        );
+}
+
+template<class T>
+IOHprofiler_Range<double> IOHprofiler_ecdf_logger<T>::error_range()
+{
+    return _range_error;
+}
+
+template<class T>
+IOHprofiler_Range<size_t> IOHprofiler_ecdf_logger<T>::eval_range() {
+    return _range_evals;
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::reset()
+{
+    _ecdf_suite.clear();
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::init_ecdf( const Problem& cur )
+{
+    if(_ecdf_suite.count(cur.pb) == 0) {
+        _ecdf_suite[cur.pb] = std::map< size_t, std::map< size_t, IOHprofiler_AttainMat >>();
+    }
+    if(_ecdf_suite[cur.pb].count(cur.dim) == 0) {
+        _ecdf_suite[cur.pb][cur.dim] = std::map< size_t, IOHprofiler_AttainMat >();
+    }
+    if(_ecdf_suite[cur.pb][cur.dim].count(cur.ins) == 0) {
+        _ecdf_suite[cur.pb][cur.dim][cur.ins] = _empty;
+    }
+    assert(_ecdf_suite.at(cur.pb).at(cur.dim).at(cur.ins).at(0).at(0) == 0);
+}
+
+template<class T>
+IOHprofiler_AttainMat& IOHprofiler_ecdf_logger<T>::current_ecdf()
+{
+    assert(_ecdf_suite.count(_current.pb) != 0);
+    assert(_ecdf_suite[_current.pb].count(_current.dim) != 0);
+    assert(_ecdf_suite[_current.pb][_current.dim].count(_current.ins) != 0);
+    return _ecdf_suite[_current.pb][_current.dim][_current.ins];
+}
+
+template<class T>
+void IOHprofiler_ecdf_logger<T>::fill_up( size_t i_error, size_t j_evals)
+{
+    IOHprofiler_AttainMat& mat = current_ecdf();
+    size_t imax = _range_error.size();
+    size_t jmax = _range_evals.size();
+    for(size_t i = i_error; i < imax; i++) {
+        // If we reach a 1 on first col of this row, no need to continue.
+        if(mat[i][j_evals] == 1) {
+            break;
+        } else {
+            for(size_t j = j_evals; j < jmax; j++) {
+                // If we reach a 1 on this col, no need to fill
+                // the remaining columns for the next rows..
+                if(mat[i][j] == 1) {
+                    jmax = j;
+                    break;
+                } else {
+                    mat[i][j] = 1;
+                }
+            } // for j
+        }
+    } // for i
+}
+
+
+/***** IOHprofiler_ecdf_sum *****/
+
+size_t IOHprofiler_ecdf_sum::operator()(const IOHprofiler_AttainSuite& attainment)
+{
+    unsigned long int sum = 0;
+    for(const auto& pbid_dimmap : attainment ) {
+        for(const auto& dimid_insmap : pbid_dimmap.second ) {
+            for(const auto& insid_mat : dimid_insmap.second) {
+                const IOHprofiler_AttainMat& mat = insid_mat.second;
+                for(const auto& row : mat) {
+                    for(const auto& item : row ) {
+                        sum += item;
+                    }
+                }
+            }
+        }
+    }
+    return sum;
+}
+

--- a/src/Template/Loggers/IOHprofiler_observer_combine.h
+++ b/src/Template/Loggers/IOHprofiler_observer_combine.h
@@ -1,0 +1,78 @@
+/// \file IOHprofiler_observer_combine.h
+/// \brief Header file for class IOHprofiler_observer_combine.
+///
+/// \author Johann Dreo
+#ifndef _IOHPROFILER_OBSERVER_COMBINE_H_
+#define _IOHPROFILER_OBSERVER_COMBINE_H_
+
+#include <vector>
+
+#include "IOHprofiler_observer.h"
+
+/** An observer that can hold several observers and call them all.
+ *
+ * Useful if one want to use several loggers without having to manage them
+ * separately.
+ *
+ * Example:
+ * @code
+    BBOB_suite bench({1},{2},{3});
+    using Input = BBOB_suite::Input_type;
+
+    IOHprofiler_ecdf_logger<Input> log_ecdf(0,6e7,20, 0,100,20);
+    IOHprofiler_csv_logger<Input> log_csv;
+
+    // Combine them all
+    IOHprofiler_observer_combine<Input> loggers(log_ecdf);
+    loggers.add(log_csv);
+
+    // Now you can single call.
+    loggers.target_suite(bench);
+    // etc.
+ * @endcode
+ *
+ * @note: Loggers are guaranteed to be called in the order they are added.
+ */
+template<class T>
+class IOHprofiler_observer_combine : public IOHprofiler_observer<T>
+{
+    public:
+        using InputType = T;
+
+        /** Takes at least one mandatory observer,
+         * because an empty instance would be illogical.
+         */
+        IOHprofiler_observer_combine( IOHprofiler_observer<T>& observer );
+
+        /** Handle several loggers at once, but you have to pass pointers.
+         *
+         * @note: you can use initializer lists to instanciate the given std::vector:
+         * @code
+            IOHprofiler_observer_combine loggers({log_ecdf, log_csv});
+         * @encode
+         */
+        IOHprofiler_observer_combine( std::vector<IOHprofiler_observer<T>*> observers );
+
+        /** Add another observer to the list.
+         */
+        void add( IOHprofiler_observer<T>& observer );
+
+        /** Observer interface @{ */
+
+        void track_suite(const IOHprofiler_suite<T>& suite);
+
+        void track_problem(const IOHprofiler_problem<T> & pb);
+
+        void do_log(const std::vector<double> &logger_info);
+
+        /** @} */
+
+    protected:
+        //! Store the managed observers.
+        std::vector<IOHprofiler_observer<T>*> _observers;
+};
+
+#include "IOHprofiler_observer_combine.hpp"
+
+#endif // _IOHPROFILER_OBSERVER_COMBINE_H_
+

--- a/src/Template/Loggers/IOHprofiler_observer_combine.hpp
+++ b/src/Template/Loggers/IOHprofiler_observer_combine.hpp
@@ -1,0 +1,43 @@
+
+template<class T>
+IOHprofiler_observer_combine<T>::IOHprofiler_observer_combine( IOHprofiler_observer<T>& observer ) :
+    _observers(1,&observer)
+{ }
+
+template<class T>
+IOHprofiler_observer_combine<T>::IOHprofiler_observer_combine( std::vector<IOHprofiler_observer<T>*> observers ) :
+    _observers(observers)
+{
+    assert(_observers.size() > 0);
+}
+
+template<class T>
+void IOHprofiler_observer_combine<T>::add( IOHprofiler_observer<T>& observer )
+{
+    _observers.push_back(&observer);
+}
+
+template<class T>
+void IOHprofiler_observer_combine<T>::track_suite(const IOHprofiler_suite<T>& suite)
+{
+    for(auto& p : _observers) {
+        p->track_suite(suite);
+    }
+}
+
+template<class T>
+void IOHprofiler_observer_combine<T>::track_problem(const IOHprofiler_problem<T> & pb)
+{
+    for(auto& p : _observers) {
+        p->track_problem(pb);
+    }
+}
+
+template<class T>
+void IOHprofiler_observer_combine<T>::do_log(const std::vector<double> &logger_info)
+{
+    for(auto& p : _observers) {
+        p->do_log(logger_info);
+    }
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,9 +7,17 @@ endfunction()
 
 file(GLOB sources "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
+list(FILTER sources EXCLUDE REGEX ".*python.*")
+
 foreach(filename ${sources})
         # File name without directory or longest extension
         get_filename_component(name ${filename} NAME_WE)
         add_simple_test(${name})
 endforeach()
+
+if(ENABLE_PYTHON_PROBLEMS AND PYTHONLIBS_FOUND)
+    add_executable(t-python-problem t-python-problem.cpp)
+    target_link_libraries(t-python-problem IOH ${PYTHON_LIBRARIES})
+    add_test(NAME t-python-problem COMMAND t-python-problem test_problem.py call)
+endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+function(add_simple_test tname)
+    add_executable(${tname} ${tname}.cpp)
+    target_link_libraries(${tname} IOH)
+    add_test(NAME ${tname} COMMAND ${tname})
+endfunction()
+
+file(GLOB sources "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+foreach(filename ${sources})
+        # File name without directory or longest extension
+        get_filename_component(name ${filename} NAME_WE)
+        add_simple_test(${name})
+endforeach()
+

--- a/tests/t-bbob-csvlogger.cpp
+++ b/tests/t-bbob-csvlogger.cpp
@@ -1,0 +1,66 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+
+#include <IOHprofiler_BBOB_suite.hpp>
+#include <IOHprofiler_problem.h>
+#include <IOHprofiler_csv_logger.h>
+
+int main()
+{
+    size_t sample_size = 3;
+    size_t runs = 3;
+
+    BBOB_suite bench;
+    // bench.loadProblem();
+    auto bench_problems = bench.IOHprofiler_suite_get_problems();
+
+    IOHprofiler_csv_logger<BBOB_suite::InputType> ioh_logger(
+            /*output_directory*/"ioh_data",
+            /*folder_name*/"experiment",
+            "solver",
+            "Random search");
+    ioh_logger.activate_logger(); // Check if result directory is writable.
+    ioh_logger.set_complete_flag(true); // Dump everything at every function call in a *.cdat file.
+
+    size_t seed = 1;
+    std::mt19937 gen(seed);
+    std::uniform_real_distribution<> dis(-5,5);
+
+    BBOB_suite::Problem_ptr pb;
+    size_t n=0;
+    while((pb = bench.get_next_problem())) {
+        for(size_t i=0; i < runs; ++i) {
+            std::clog << "[";
+            std::clog.flush();
+            auto d = pb->IOHprofiler_get_number_of_variables();
+            ioh_logger.track_problem(*pb);
+
+            std::vector<double> lowerbounds = pb->IOHprofiler_get_lowerbound();
+            std::vector<double> upperbounds = pb->IOHprofiler_get_upperbound();
+
+            for(size_t s=0; s < sample_size; ++s) {
+                std::clog << ".";
+                std::clog.flush();
+
+                std::vector<double> sol;
+                sol.reserve(d);
+                std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
+
+                double f = pb->evaluate(sol);
+                ioh_logger.write_line(pb->loggerInfo());
+            }
+
+            n++;
+            std::clog << "]";
+            std::clog.flush();
+        }
+        std::clog << std::endl;
+    } // for name_id
+
+    std::clog << "Done " << n << " function test" << std::endl;
+}

--- a/tests/t-bbob-random.cpp
+++ b/tests/t-bbob-random.cpp
@@ -1,0 +1,63 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+
+#include <IOHprofiler_BBOB_suite.hpp>
+#include <IOHprofiler_problem.h>
+
+int main()
+{
+    size_t sample_size = 10;
+
+    BBOB_suite bench;
+    // bench.loadProblem();
+    auto bench_problems = bench.IOHprofiler_suite_get_problems();
+    assert(bench_problems.size() == 24);
+
+    size_t seed = 1;
+    std::mt19937 gen(seed);
+    std::uniform_real_distribution<> dis(-5,5);
+
+    BBOB_suite::Problem_ptr pb;
+    size_t n=0;
+    while((pb = bench.get_next_problem())) {
+        std::clog << "[";
+        std::clog.flush();
+        auto d = pb->IOHprofiler_get_number_of_variables();
+
+        assert(pb->IOHprofiler_get_number_of_objectives() == 1);
+        assert(pb->IOHprofiler_get_optimization_type() == IOH_optimization_type::Minimization);
+
+        std::vector<double> lowerbounds = pb->IOHprofiler_get_lowerbound();
+        std::vector<double> upperbounds = pb->IOHprofiler_get_upperbound();
+        assert(lowerbounds.size() == upperbounds.size());
+        assert(lowerbounds.size() > 0);
+
+        for(size_t i=0; i < lowerbounds.size(); ++i) {
+            assert(lowerbounds.at(i) = -5);
+            assert(upperbounds.at(i) =  5);
+        }
+
+        for(size_t s=0; s < sample_size; ++s) {
+            std::clog << ".";
+            std::clog.flush();
+
+            std::vector<double> sol;
+            sol.reserve(d);
+            std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
+
+            double f = pb->evaluate(sol);
+            assert(std::isfinite(f));
+        }
+
+        n++;
+        std::clog << "]" << std::endl;
+        std::clog.flush();
+    } // for name_id
+
+    std::clog << "Done " << n << " function test" << std::endl;
+}

--- a/tests/t-ecdf_logger.cpp
+++ b/tests/t-ecdf_logger.cpp
@@ -1,0 +1,93 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+
+#include <IOHprofiler_BBOB_suite.hpp>
+#include <IOHprofiler_problem.h>
+#include <IOHprofiler_ecdf_logger.h>
+
+int main()
+{
+    size_t sample_size = 100;
+
+    std::vector<int> pbs = {1,2};
+    std::vector<int> ins = {1,2};
+    std::vector<int> dims = {2,10};
+
+    BBOB_suite bench(pbs,ins,dims);
+    // bench.loadProblem();
+
+    size_t ecdf_width = 20;
+    using Logger = IOHprofiler_ecdf_logger<BBOB_suite::InputType>;
+    IOHprofiler_RangeLog<double> error(0,6e7,ecdf_width);
+    IOHprofiler_RangeLog<size_t> evals(0,sample_size,ecdf_width);
+    Logger logger(error, evals);
+
+    logger.activate_logger();
+    logger.track_suite(bench);
+
+    size_t seed = 5;
+    std::mt19937 gen(seed);
+    // std::mt19937 gen(time(0));
+    std::uniform_real_distribution<> dis(-5,5);
+
+    BBOB_suite::Problem_ptr pb;
+    size_t n=0;
+    while((pb = bench.get_next_problem())) {
+        logger.track_problem(*pb);
+
+        std::clog << "Problem " << pb->IOHprofiler_get_problem_id()
+                  << " (" << pb->IOHprofiler_get_problem_name() << ")"
+                  << " instance " << pb->IOHprofiler_get_instance_id()
+                  << ", optimum: ";
+        for(double o : pb->IOHprofiler_get_optimal()) {
+            std::clog << o << " ";
+        }
+        std::clog << std::endl;
+
+        size_t d = pb->IOHprofiler_get_number_of_variables();
+        for(size_t s=0; s < sample_size; ++s) {
+            std::vector<double> sol;
+            sol.reserve(d);
+            std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
+
+            double f = pb->evaluate(sol);
+            logger.do_log(pb->loggerInfo());
+        }
+
+        n++;
+    } // for name_id
+    std::clog << "Done " << n << " function test" << std::endl;
+
+    size_t i,j,k;
+    std::tie(i,j,k) = logger.size();
+    std::clog << i << " problems × " << j << " dimensions × " << k << " instances" << std::endl;
+    assert(i == pbs.size());
+    assert(j == dims.size());
+    assert(k == ins.size());
+
+    for(int ipb : pbs) {
+        for(int idim : dims) {
+            for(int iins : ins) {
+                std::clog << "Problem " << ipb
+                          << ", dimension " << idim
+                          << ", instance " << iins
+                          << ": " << std::endl;
+                const auto& m = logger.at(ipb, iins, idim);
+                std::clog << m << std::endl;
+                assert(m.size() == ecdf_width);
+                assert(m[0].size() == ecdf_width);
+            }
+        }
+    }
+
+    IOHprofiler_ecdf_sum sum;
+    size_t s = sum(logger.data());
+    std::clog << "Attainments sum: ";
+    std::cout << s << std::endl;
+    assert(s <= sample_size * ecdf_width * ecdf_width * i * j * k);
+}

--- a/tests/t-logger-combination.cpp
+++ b/tests/t-logger-combination.cpp
@@ -1,0 +1,67 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+
+#include <IOHprofiler_BBOB_suite.hpp>
+#include <IOHprofiler_problem.h>
+#include <IOHprofiler_ecdf_logger.h>
+#include <IOHprofiler_csv_logger.h>
+#include <IOHprofiler_observer_combine.h>
+
+int main()
+{
+    size_t sample_size = 100;
+
+    std::vector<int> pbs = {1,2};
+    std::vector<int> ins = {1,2};
+    std::vector<int> dims = {2,10};
+
+    BBOB_suite bench(pbs,ins,dims);
+    using Input = BBOB_suite::InputType;
+    // bench.loadProblem();
+
+    IOHprofiler_ecdf_logger<Input> log_ecdf(0,6e7,20, 0,sample_size,20);
+    IOHprofiler_csv_logger<Input> log_csv; // Use default arguments.
+    log_csv.activate_logger(); // FIXME only in CSV logger, should be called by constructor?
+
+    IOHprofiler_observer_combine<Input> loggers({&log_ecdf,&log_csv});
+
+    loggers.track_suite(bench);
+
+    size_t seed = 5;
+    std::mt19937 gen(seed);
+    // std::mt19937 gen(time(0));
+    std::uniform_real_distribution<> dis(-5,5);
+
+    BBOB_suite::Problem_ptr pb;
+    size_t n=0;
+    while((pb = bench.get_next_problem())) {
+        loggers.track_problem(*pb);
+
+        std::clog << "Problem " << pb->IOHprofiler_get_problem_id()
+                  << " (" << pb->IOHprofiler_get_problem_name() << ")"
+                  << " instance " << pb->IOHprofiler_get_instance_id()
+                  << ", optimum: ";
+        for(double o : pb->IOHprofiler_get_optimal()) {
+            std::clog << o << " ";
+        }
+        std::clog << std::endl;
+
+        size_t d = pb->IOHprofiler_get_number_of_variables();
+        for(size_t s=0; s < sample_size; ++s) {
+            std::vector<double> sol;
+            sol.reserve(d);
+            std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
+
+            double f = pb->evaluate(sol);
+            loggers.do_log(pb->loggerInfo());
+        }
+
+        n++;
+    } // for name_id
+    std::clog << "Done " << n << " function test" << std::endl;
+}

--- a/tests/t-python-problem.cpp
+++ b/tests/t-python-problem.cpp
@@ -1,0 +1,23 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <random>
+
+#include <IOHprofiler_extern_python.h>
+#include <IOHprofiler_problem.h>
+
+int main(int argc, char** argv)
+{
+    assert(argc == 3);
+
+    IOHprofiler_ExternPythonProblem<int> pypb(argv[1], argv[2]);
+
+    size_t d = pypb.IOHprofiler_get_number_of_variables();
+    std::vector<int> sol(d,6);
+
+    double fit = pypb.evaluate(sol);
+    std::cout << fit << std::endl;
+}

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -1,0 +1,43 @@
+import ioh
+
+class MyProblem(ioh.Problem):
+    def __init__(self, dim=4):
+        self.instance = 1
+        self.dimension = dim
+
+    def call(self, *args ):
+        sum = 0
+        for x in args:
+            sum += x*x
+        return sum
+
+    def get_instance(self):
+        return self.instance
+
+    def get_number_of_variables(self):
+        return self.dimension
+
+    def get_lowerbound(self):
+        return [-5] * self.dimension
+
+    def get_upperbound(self):
+        return [5] * self.dimension
+
+    def get_minimization(self):
+        return True
+
+    def get_problem_id(self):
+        return 1
+
+    def get_name(self):
+        return "First_test"
+
+    def get_type(self):
+        return "Test_benchmark"
+
+    def get_number_of_objectives(self):
+        return 1
+
+
+pb1 = MyProblem()
+


### PR DESCRIPTION
This adds a new logger which computes ECDF on the fly and a problem interface toward Python modules.

# Logger

The new logger is able to computes bi-dimensional (i.e. target/budget) discrete ECDF in memory (no files written). The objective of this feature is to be able to do algorithm selection on an IOH suite: an algorithm would plug on a suite, run, then use this logger's helpers classes to extract a performance statistic from the whole set of runs.

For your perfect understanding, an example of how it can be used is given on the ParadisEO framework: https://github.com/nojhan/paradiseo/blob/master/problems/eval/eoEvalIOH.h#L343

Summary of the modifications:

Refactoring:
- Makes observer an abstract class with a clear interface which subclasses have to implement (pure virtual functions, such that the interface is enforced by the compiler).
- Makes observer a template, to generalize the input type (so far int and double, but may be extended).

Core features:
- Adds a logger, which computes bi-dim ECDF in memory.
- Adds classes which allow to extract performance metrics from it.
- Adds an observer which can call several loggers at once (e.g. useful to copmute the ECDF _and_ log to CSV files).

Dev features:
- Adds a testing architecture using ctest. Just call `ctest` and it will run several tests for you and dispaly a report. Useful to check for regression and can be integrated it Github's continuous integration.

Fix:
- Print error messages if csv_logger::create_folder fails. Note that this function is a weak point of IOH, raising to C++17 would allow for using std::filesystem for this kind of feature, which would be far more robust.

# Problem interface

This adds a proxy for problems written in the Python programming language.

Given a Python module in which exists an instance of a class
honoring the needed interface, this class be be use as a proxy
that will call the Python code of a problem.

```cpp
 IOHprofiler_ExternPythonProblem<int> pypb("mymodule", "myinstance");
 size_t d = pypb.IOHprofiler_get_number_of_variables();
 std::vector<int> sol(d,6);
 double fit = pypb.evaluate(sol);
```

@note Given that this class operates on a class instance
a given Python module may host several problems.
However, you still need to create one C++ class instance
per Python class instance.

The interface is formed by several member functions,
which should be implemented by the targeted Python class.

An abstract base class enforcing the default interface
is distributed with IOH in the `ioh.py` file.
Users may inherit from this class to ensure that they
correctly implemented the interface, albeit
this is not mandatory (given that Python does not
enforce type checking).

Default names of the members can be changed
by modifying the values of the `*api*` parameters
passed to this class' constructor.

All the `get_*` member functions of the Python interface
just return a parameter.
Only the `call` function takes arguments
(i.e. a candidate solution to the problem).
This class send a call tuple to the Python function,
so that you can either define a fixed number of
explicit variables, either capture the tuple
as a positional argument expansion:

````python
 # Example for variable dimensions:
 def call(self, *args ):
     return sum(*args)

 # Example for fixed dimensions:
 def call(self, x0, x1, x2):
````

# Notes to the maintainer

- As a consequence, this PR is done on developing, which I believe is the most appropriate way to allow easy merging for you. I'm doing a duplicate PR on the `Competition` branch for you to keep track of it (see PR #45).
- The *csv_logger class exhibit a somehow complicated interface, with a lot of additional functions on top of the virtuals of *observer (e.g. `activate_logger`, `clear_logger`, etc). I tried to be conservative on the interface., so I did not raised those functions to the observer, but you may want to do so, if appropriate.
- Alternatively, you may want to call them in constructors, like I did for `loadProblem`, which I think is the most elegant way for all functions related to intialization (as it does not force the user to remember to call them).
