### PR TITLE
feat/fix: add a flag for problems with known optimum, use it in ECDF logger

### DIFF
--- a/src/Template/IOHprofiler_problem.h
+++ b/src/Template/IOHprofiler_problem.h
@@ -33,7 +33,7 @@ public:
     number_of_objectives(1),
     lowerbound(std::vector<InputType> (number_of_variables) ), 
     upperbound(std::vector<InputType> (number_of_variables) ),
-    optimal(std::vector<double>(number_of_objectives) ),
+    optimal( /* std::vector<double>(number_of_objectives) <- do not initialise, so as to check for the exetrn initialization using size */),
     optimalFound(false),
     raw_objectives(std::vector<double>(number_of_objectives)),
     transformed_objectives(std::vector<double>(number_of_objectives)),
@@ -232,6 +232,8 @@ public:
   void IOHprofiler_set_best_variables(const InputType best_variables);
 
   void IOHprofiler_set_best_variables(const std::vector<InputType> &best_variables);
+
+  bool IOHprofiler_has_optimal() const;
 
   std::vector<double> IOHprofiler_get_optimal() const;
 

--- a/src/Template/IOHprofiler_problem.hpp
+++ b/src/Template/IOHprofiler_problem.hpp
@@ -259,7 +259,14 @@ template <class InputType> void IOHprofiler_problem<InputType>::IOHprofiler_set_
   this->best_variables = best_variables;
 }
 
+template <class InputType> bool IOHprofiler_problem<InputType>::IOHprofiler_has_optimal() const {
+  return this->optimal.size() == this->IOHprofiler_get_number_of_objectives();
+}
+
 template <class InputType> std::vector<double> IOHprofiler_problem<InputType>::IOHprofiler_get_optimal() const {
+  // FIXME unsure if one want to raise an exception in Release mode also?
+  // Assert that the optimum have been initialized.
+  assert(this->IOHprofiler_has_optimal());
   return this->optimal;
 }
 

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -133,6 +133,7 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
             int pb;
             int dim;
             int ins;
+            bool has_opt;
             std::vector<double> opt;
             IOH_optimization_type maxmin;
         };


### PR DESCRIPTION
- feat: add a flag for problem for which the known optimum has been
  initialized.
- fix: use it in ECDF logger to correctly branch between min/max
  attainment matrix filling.
- add a log stating if we compute absolute or error ECDF.
- fix a potential bug about using `best_so_far_transformed_objectives` instead of `raw_objectives` (TBC)

An open question remains in `IOHprofiler_problem.hpp:267` as I don't know the policy about user operation errors related to state management.

Also in `IOHprofiler_ecdf_logger.hpp:160`, I used `info[4]` instead of `info[2]` to be consistent with line `157`, but I'm ensure this is the expected behavior (some thoughts as in-code-comments/documentation would be welcomed).