### PR TITLE
ECDF for independent runs on the same instance

### DIFF
--- a/src/Template/IOHprofiler_observer.h
+++ b/src/Template/IOHprofiler_observer.h
@@ -22,9 +22,9 @@ public:
   /** API for subclasses @{ */
   using InputType = T;
 
-  virtual void track_problem(const IOHprofiler_problem<InputType> & problem) = 0;
+  virtual void track_problem(IOHprofiler_problem<InputType> & problem) = 0;
 
-  virtual void track_suite(const IOHprofiler_suite<T>& suite) = 0;
+  virtual void track_suite(IOHprofiler_suite<T>& suite) = 0;
 
   virtual void do_log(const std::vector<double> &log_info) = 0;
   /** }@ */

--- a/src/Template/IOHprofiler_problem.h
+++ b/src/Template/IOHprofiler_problem.h
@@ -27,7 +27,8 @@ template <class InputType> class IOHprofiler_problem
 public:
   IOHprofiler_problem(int instance_id = DEFAULT_INSTANCE, int dimension = DEFAULT_DIMENSION) : 
     problem_id(DEFAULT_PROBLEM_ID), 
-    instance_id(instance_id), 
+    instance_id(instance_id),
+    run_id(1),
     maximization_minimization_flag(IOH_optimization_type::Maximization),
     number_of_variables(dimension), 
     number_of_objectives(1),
@@ -176,6 +177,10 @@ public:
   /// \param instance_id 
   void IOHprofiler_set_instance_id(int instance_id);
 
+  std::size_t IOHprofiler_get_run_id() const;
+
+  void IOHprofiler_set_next_run_id(std::size_t run_id);
+
   std::string IOHprofiler_get_problem_name() const;
 
   void IOHprofiler_set_problem_name(std::string problem_name);
@@ -262,7 +267,8 @@ public:
 private:
   int problem_id; /// < problem id, assigned as being added into a suite.
   int instance_id; /// < evaluate function is validated with instance and dimension. set default to avoid invalid class.
-  
+  std::size_t run_id; /// < id of independent runs on the same instance.
+
   std::string problem_name;
   std::string problem_type;   /// todo. make it as enum.
 

--- a/src/Template/IOHprofiler_problem.hpp
+++ b/src/Template/IOHprofiler_problem.hpp
@@ -130,6 +130,14 @@ template <class InputType> void IOHprofiler_problem<InputType>::IOHprofiler_set_
   this->calc_optimal();
 }
 
+template <class InputType> std::size_t IOHprofiler_problem<InputType>::IOHprofiler_get_run_id() const {
+  return this->run_id;
+}
+
+template <class InputType> void IOHprofiler_problem<InputType>::IOHprofiler_set_next_run_id(std::size_t run_id) {
+  this->run_id = run_id;
+}
+
 template <class InputType> std::string IOHprofiler_problem<InputType>::IOHprofiler_get_problem_name() const {
   return this->problem_name;
 }

--- a/src/Template/Loggers/IOHprofiler_csv_logger.h
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.h
@@ -55,11 +55,11 @@ public:
   void track_problem(const int problem_id, const int dimension, const int instance, const std::string problem_name, const IOH_optimization_type maximization_minimization_flag);
 
 
-  void track_problem(const IOHprofiler_problem<T> & problem);
+  void track_problem(IOHprofiler_problem<T> & problem);
 
   void track_suite(std::string suite_name);
 
-  void track_suite(const IOHprofiler_suite<T>& suite)
+  void track_suite(IOHprofiler_suite<T>& suite)
   {
     this->track_suite(suite.IOHprofiler_suite_get_suite_name());
   }

--- a/src/Template/Loggers/IOHprofiler_csv_logger.hpp
+++ b/src/Template/Loggers/IOHprofiler_csv_logger.hpp
@@ -236,7 +236,7 @@ void IOHprofiler_csv_logger<T>::track_problem(const int problem_id, const int di
 
 
 template<class T>
-void IOHprofiler_csv_logger<T>::track_problem(const IOHprofiler_problem<T> & problem) {
+void IOHprofiler_csv_logger<T>::track_problem(IOHprofiler_problem<T> & problem) {
   // this->tracked_problem_int = nullptr;
   // this->tracked_problem_double = nullptr;
 

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -91,7 +91,8 @@ using IOHprofiler_AttainSuite =
     std::map< size_t,         // problem
         std::map< size_t,     // dim
             std::map< size_t, // instance
-                 IOHprofiler_AttainMat >>>; // ECDF
+                 std::map< size_t, // run
+                    IOHprofiler_AttainMat >>>>; // ECDF
 
 /** An observer which stores bi-dimensional error/evaluations discretized attainment matrices.
  *
@@ -194,8 +195,19 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
          * First index: problem id,
          * second index: instance id,
          * third index: dimension id.
+         * fourth index: run id
          */
-        const IOHprofiler_AttainMat& at(size_t problem_id, size_t instance_id, size_t dim_id) const;
+        const IOHprofiler_AttainMat& at(size_t problem_id, size_t instance_id, size_t dim_id, size_t run_id) const;
+
+        /** Access an averaged attainment matrix of multiple runs on a problem
+         *
+         * @note Use the same indices order than IOHprofiler_problem.
+         *
+         * First index: problem id,
+         * second index: instance id,
+         * third index: dimension id.
+         */
+        IOHprofiler_AttainMat at(size_t problem_id, size_t instance_id, size_t dim_id) const;
 
         /** Returns the size of the computed data, in its internal order.
          *
@@ -246,6 +258,9 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
 
         //! Currently targeted problem metadata.
         Problem _current;
+        
+        ///! The number of independent runs have been tested on _current problem.
+        int _current_run; 
 
         //! An attainment matrix filled with zeros, copied for each new problem/instance/dim.
         IOHprofiler_AttainMat _empty;

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -50,13 +50,24 @@ class IOHprofiler_RangeLinear : public IOHprofiler_Range<R>
         virtual size_t index( double x );
 };
 
-/** Logarithmic (base 10) range.
+/** Logarithmic (base 10) range for minimization.
  */
 template<class R>
-class IOHprofiler_RangeLog : public IOHprofiler_Range<R>
+class IOHprofiler_RangeLog_Min : public IOHprofiler_Range<R>
 {
     public:
-        IOHprofiler_RangeLog(R min, R max, size_t size);
+        IOHprofiler_RangeLog_Min(R min, R max, size_t size);
+
+        virtual size_t index( double x );
+};
+
+/** Logarithmic (base 10) range for maximization.
+ */
+template<class R>
+class IOHprofiler_RangeLog_Max : public IOHprofiler_Range<R>
+{
+    public:
+        IOHprofiler_RangeLog_Max(R min, R max, size_t size);
 
         virtual size_t index( double x );
 };
@@ -259,10 +270,10 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
 
     private:
         //! Default range for errors is logarithmic.
-        IOHprofiler_RangeLog<double> _default_range_error;
+        IOHprofiler_RangeLog_Min<double> _default_range_error;
 
         //! Default range for evaluations is logarithmic.
-        IOHprofiler_RangeLog<size_t> _default_range_evals;
+        IOHprofiler_RangeLog_Min<size_t> _default_range_evals;
 
         /** @} */
 };

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -82,9 +82,10 @@ static std::ostream& operator<<(std::ostream& out, const IOHprofiler_AttainMat& 
 
 /** Type used to store all bi-dimensional attainment functions.
  *
- * First dimension is the problem id,
- * second dimension is the dimension id,
- * last dimension is the instance id.
+ * The first dimension is the problem id,
+ * the second dimension is the dimension id,
+ * the third dimension is the instance id,
+ * and the last dimension is the run id.
  * Every item is an IOHprofiler_AttainMat.
  */
 using IOHprofiler_AttainSuite =
@@ -134,6 +135,7 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
             int pb;
             int dim;
             int ins;
+            size_t run;
             std::vector<double> opt;
             IOH_optimization_type maxmin;
         };
@@ -168,10 +170,10 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
         void activate_logger();
 
         //! Not used, but part of the interface.
-        void track_suite(const IOHprofiler_suite<T>&);
+        void track_suite(IOHprofiler_suite<T>&);
 
         //! Initialize on the given problem.
-        void track_problem(const IOHprofiler_problem<T> & pb);
+        void track_problem(IOHprofiler_problem<T> & pb);
 
         /** Actually store information about the last evaluation.
          *
@@ -198,16 +200,6 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
          * fourth index: run id
          */
         const IOHprofiler_AttainMat& at(size_t problem_id, size_t instance_id, size_t dim_id, size_t run_id) const;
-
-        /** Access an averaged attainment matrix of multiple runs on a problem
-         *
-         * @note Use the same indices order than IOHprofiler_problem.
-         *
-         * First index: problem id,
-         * second index: instance id,
-         * third index: dimension id.
-         */
-        IOHprofiler_AttainMat at(size_t problem_id, size_t instance_id, size_t dim_id) const;
 
         /** Returns the size of the computed data, in its internal order.
          *
@@ -258,9 +250,6 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
 
         //! Currently targeted problem metadata.
         Problem _current;
-        
-        ///! The number of independent runs have been tested on _current problem.
-        int _current_run; 
 
         //! An attainment matrix filled with zeros, copied for each new problem/instance/dim.
         IOHprofiler_AttainMat _empty;

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
@@ -44,19 +44,31 @@ size_t IOHprofiler_RangeLinear<R>::index( double x )
 }
 
 
-/***** IOHprofiler_RangeLog ****/
+/***** IOHprofiler_RangeLog_Min ****/
 
 template<class R>
-IOHprofiler_RangeLog<R>::IOHprofiler_RangeLog(R min, R max, size_t size) :
+IOHprofiler_RangeLog_Min<R>::IOHprofiler_RangeLog_Min(R min, R max, size_t size) :
     IOHprofiler_Range<R>(min,max,size)
 { }
 
 template<class R>
-size_t IOHprofiler_RangeLog<R>::index( double x )
+size_t IOHprofiler_RangeLog_Min<R>::index( double x )
 {
     return std::floor( std::log10(1+(x-this->min())) / std::log10(1+this->length()) * this->size() );
 }
 
+/***** IOHprofiler_RangeLog_Max ****/
+
+template<class R>
+IOHprofiler_RangeLog_Max<R>::IOHprofiler_RangeLog_Max(R min, R max, size_t size) :
+    IOHprofiler_Range<R>(min,max,size)
+{ }
+
+template<class R>
+size_t IOHprofiler_RangeLog_Max<R>::index( double x )
+{
+    return this->size() - std::floor( std::log10(1+(this->max()-x)) / std::log10(1+this->length()) * this->size() );
+}
 
 /***** IOHprofiler_AttainMat *****/
 

--- a/src/Template/Loggers/IOHprofiler_observer_combine.h
+++ b/src/Template/Loggers/IOHprofiler_observer_combine.h
@@ -59,9 +59,9 @@ class IOHprofiler_observer_combine : public IOHprofiler_observer<T>
 
         /** Observer interface @{ */
 
-        void track_suite(const IOHprofiler_suite<T>& suite);
+        void track_suite(IOHprofiler_suite<T>& suite);
 
-        void track_problem(const IOHprofiler_problem<T> & pb);
+        void track_problem(IOHprofiler_problem<T> & pb);
 
         void do_log(const std::vector<double> &logger_info);
 

--- a/src/Template/Loggers/IOHprofiler_observer_combine.hpp
+++ b/src/Template/Loggers/IOHprofiler_observer_combine.hpp
@@ -18,7 +18,7 @@ void IOHprofiler_observer_combine<T>::add( IOHprofiler_observer<T>& observer )
 }
 
 template<class T>
-void IOHprofiler_observer_combine<T>::track_suite(const IOHprofiler_suite<T>& suite)
+void IOHprofiler_observer_combine<T>::track_suite(IOHprofiler_suite<T>& suite)
 {
     for(auto& p : _observers) {
         p->track_suite(suite);
@@ -26,7 +26,7 @@ void IOHprofiler_observer_combine<T>::track_suite(const IOHprofiler_suite<T>& su
 }
 
 template<class T>
-void IOHprofiler_observer_combine<T>::track_problem(const IOHprofiler_problem<T> & pb)
+void IOHprofiler_observer_combine<T>::track_problem(IOHprofiler_problem<T> & pb)
 {
     for(auto& p : _observers) {
         p->track_problem(pb);

--- a/tests/t-ecdf_logger.cpp
+++ b/tests/t-ecdf_logger.cpp
@@ -17,6 +17,7 @@ int main()
     std::vector<int> pbs = {1,2};
     std::vector<int> ins = {1,2};
     std::vector<int> dims = {2,10};
+    size_t runs = 2;
 
     BBOB_suite bench(pbs,ins,dims);
     // bench.loadProblem();
@@ -38,25 +39,32 @@ int main()
     BBOB_suite::Problem_ptr pb;
     size_t n=0;
     while((pb = bench.get_next_problem())) {
-        logger.track_problem(*pb);
+        size_t r=1;
+        while(r <= runs) {
+            pb->reset_problem();
+            logger.track_problem(*pb);
+        
 
-        std::clog << "Problem " << pb->IOHprofiler_get_problem_id()
-                  << " (" << pb->IOHprofiler_get_problem_name() << ")"
-                  << " instance " << pb->IOHprofiler_get_instance_id()
-                  << ", optimum: ";
-        for(double o : pb->IOHprofiler_get_optimal()) {
-            std::clog << o << " ";
-        }
-        std::clog << std::endl;
+            std::clog << "Problem " << pb->IOHprofiler_get_problem_id()
+                      << " (" << pb->IOHprofiler_get_problem_name() << ")"
+                      << " instance " << pb->IOHprofiler_get_instance_id()
+                      << ", optimum: ";
+            for(double o : pb->IOHprofiler_get_optimal()) {
+                std::clog << o << " ";
+            }
+            std::clog << std::endl;
 
-        size_t d = pb->IOHprofiler_get_number_of_variables();
-        for(size_t s=0; s < sample_size; ++s) {
-            std::vector<double> sol;
-            sol.reserve(d);
-            std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
+            size_t d = pb->IOHprofiler_get_number_of_variables();
+            for(size_t s=0; s < sample_size; ++s) {
+                std::vector<double> sol;
+                sol.reserve(d);
+                std::generate_n(std::back_inserter(sol), d, [&dis,&gen](){return dis(gen);});
 
-            double f = pb->evaluate(sol);
-            logger.do_log(pb->loggerInfo());
+                double f = pb->evaluate(sol);
+                logger.do_log(pb->loggerInfo());
+            }
+
+            r++;
         }
 
         n++;
@@ -73,14 +81,17 @@ int main()
     for(int ipb : pbs) {
         for(int idim : dims) {
             for(int iins : ins) {
-                std::clog << "Problem " << ipb
-                          << ", dimension " << idim
-                          << ", instance " << iins
-                          << ": " << std::endl;
-                const auto& m = logger.at(ipb, iins, idim);
-                std::clog << m << std::endl;
-                assert(m.size() == ecdf_width);
-                assert(m[0].size() == ecdf_width);
+                for (size_t r = 1; r <= runs; ++r) {
+                    std::clog << "Problem " << ipb
+                              << ", dimension " << idim
+                              << ", instance " << iins
+                              << ", run " << r
+                              << ": " << std::endl;
+                    const auto& m = logger.at(ipb, iins, idim, r);
+                    std::clog << m << std::endl;
+                    assert(m.size() == ecdf_width);
+                    assert(m[0].size() == ecdf_width);
+                }
             }
         }
     }
@@ -89,5 +100,5 @@ int main()
     size_t s = sum(logger.data());
     std::clog << "Attainments sum: ";
     std::cout << s << std::endl;
-    assert(s <= sample_size * ecdf_width * ecdf_width * i * j * k);
+    assert(s <= sample_size * ecdf_width * ecdf_width * i * j * k * runs);
 }

--- a/tests/t-ecdf_logger.cpp
+++ b/tests/t-ecdf_logger.cpp
@@ -24,8 +24,8 @@ int main()
 
     size_t ecdf_width = 20;
     using Logger = IOHprofiler_ecdf_logger<BBOB_suite::InputType>;
-    IOHprofiler_RangeLog<double> error(0,6e7,ecdf_width);
-    IOHprofiler_RangeLog<size_t> evals(0,sample_size,ecdf_width);
+    IOHprofiler_RangeLog_Min<double> error(0,6e7,ecdf_width);
+    IOHprofiler_RangeLog_Min<size_t> evals(0,sample_size,ecdf_width);
     Logger logger(error, evals);
 
     logger.activate_logger();


### PR DESCRIPTION
- Feature: add additional  dimension for IOHprofiler_AttainSuite, which allows to store IOHprofiler_AttainMat for multiple runs on the same instance.

Now the access to attainment matrix of (problem_id, dimension_id, instance_id) is an average of multiple runs : https://github.com/IOHprofiler/IOHexperimenter/blob/2372dc23108cbe6bec4f0641dfe1f3d9e496a83c/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp#L204

Hi @nojhan , could you please also review this? Thanks!
 