### PR TITLE
Fix ecdf_logger accessors to ranges

### DIFF
--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.h
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.h
@@ -209,10 +209,10 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
         std::tuple<size_t, size_t, size_t> size();
 
         /** Accessor to the range used for error targets in this logger instance. */
-        IOHprofiler_Range<double> error_range();
+        IOHprofiler_Range<double>& error_range();
 
         /** Accessor to the range used for evaluations targets in this logger instance. */
-        IOHprofiler_Range<size_t> eval_range();
+        IOHprofiler_Range<size_t>& eval_range();
 
         /** @} */
 
@@ -236,6 +236,13 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
 
         /** @} */
 
+    private:
+        //! Default range for errors is logarithmic.
+        IOHprofiler_RangeLog<double> _default_range_error;
+
+        //! Default range for evaluations is logarithmic.
+        IOHprofiler_RangeLog<size_t> _default_range_evals;
+
     protected:
         /** Internal members  @{ */
 
@@ -253,13 +260,6 @@ class IOHprofiler_ecdf_logger : public IOHprofiler_observer<T>
 
         //! The whole main data structure.
         IOHprofiler_AttainSuite _ecdf_suite;
-
-    private:
-        //! Default range for errors is logarithmic.
-        IOHprofiler_RangeLog<double> _default_range_error;
-
-        //! Default range for evaluations is logarithmic.
-        IOHprofiler_RangeLog<size_t> _default_range_evals;
 
         /** @} */
 };

--- a/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
+++ b/src/Template/Loggers/IOHprofiler_ecdf_logger.hpp
@@ -161,8 +161,9 @@ void IOHprofiler_ecdf_logger<T>::do_log(const std::vector<double>& infos)
     }
 
     // If this target is worst than the domain.
-    if(   _range_evals.min() > evals or evals > _range_evals.max()
-       or _range_error.min() > err   or   err > _range_error.max() ) {
+    if(    evals < _range_evals.min() or _range_evals.max() < evals
+        or   err < _range_error.min() or _range_error.max() < err
+      ) {
         // Discard it.
         std::clog << "WARNING: target out of domain. "
                   << "value:" << err   << " [" << _range_error.min() << "," << _range_error.max() << "], "
@@ -176,21 +177,11 @@ void IOHprofiler_ecdf_logger<T>::do_log(const std::vector<double>& infos)
         size_t j_evals;
 
         // If the target is in domain
-        if(_range_error.min() <= err and err <= _range_error.max()) {
-            i_error = _range_error.index(err);
+        assert(_range_error.min() <= err and err <= _range_error.max());
+        i_error = _range_error.index(err);
 
-        // If the target is better than the domain
-        } else if( err < _range_error.min() ) {
-            i_error = 0;
-        }
-
-        // Same for evaluations...
-        if(_range_evals.min() <= evals and evals <= _range_evals.max()) {
-            j_evals = _range_evals.index(evals);
-
-        } else if( evals < _range_evals.min() ) {
-            j_evals = 0;
-        }
+        assert(_range_evals.min() <= evals and evals <= _range_evals.max());
+        j_evals = _range_evals.index(evals);
 
         // Fill up the dominated quadrant of the attainment matrix with ones
         // (either the upper/upper or lower/lower, depending on if it's
@@ -225,13 +216,13 @@ std::tuple<size_t, size_t, size_t> IOHprofiler_ecdf_logger<T>::size()
 }
 
 template<class T>
-IOHprofiler_Range<double> IOHprofiler_ecdf_logger<T>::error_range()
+IOHprofiler_Range<double>& IOHprofiler_ecdf_logger<T>::error_range()
 {
     return _range_error;
 }
 
 template<class T>
-IOHprofiler_Range<size_t> IOHprofiler_ecdf_logger<T>::eval_range() {
+IOHprofiler_Range<size_t>& IOHprofiler_ecdf_logger<T>::eval_range() {
     return _range_evals;
 }
 


### PR DESCRIPTION
The previous ranges accessors were returning a copy of the abstract base class, which cannot be instantiated.
The proposed accessors return references, which allows to use the abstract base class interface.

The commit also adds some code cleaning.