### PR TITLE
Fix issue #94

### DIFF
--- a/containers/issue94.dockdef
+++ b/containers/issue94.dockdef
@@ -1,0 +1,42 @@
+
+FROM ubuntu
+
+# Dependencies
+RUN apt -y update
+RUN apt -y install software-properties-common
+RUN add-apt-repository universe
+RUN apt -y update
+RUN apt -y dist-upgrade
+RUN apt -y install git g++-8 cmake make
+RUN apt clean
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 80
+RUN update-alternatives --set c++ /usr/bin/g++-8
+
+# Temporary directory where we are going to build everything.
+RUN tmpdir=$(mktemp -d)
+RUN mkdir -p ${tmpdir}/ioh/
+WORKDIR ${tmpdir}/ioh/
+
+# Build IOH
+RUN git clone --branch analyzer-logger --single-branch --recurse-submodules https://github.com/jdreo/IOHexperimenter.git
+WORKDIR ${tmpdir}/ioh/IOHexperimenter
+RUN mkdir -p debug
+WORKDIR ${tmpdir}/ioh/IOHexperimenter/debug
+RUN cmake -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTS=ON -D BUILD_EXAMPLE=ON -D BUILD_GMOCK=ON ..
+RUN make
+
+# Install
+RUN mkdir -p /usr/local/opt/ioh
+RUN cp tests/test_* /usr/local/opt/ioh/
+
+# Clean-up
+RUN rm -rf ${tmpdir}
+
+# keep cmake to run ctest
+RUN apt -y purge software-properties-common git g++-8 make
+RUN apt -y --purge autoremove
+RUN apt -y autoclean
+RUN apt clean
+
+WORKDIR /usr/local/opt/ioh/
+CMD ['/usr/local/opt/ioh/test_store']

--- a/containers/issue94.sh
+++ b/containers/issue94.sh
@@ -1,0 +1,2 @@
+docker build -f issue94.dockdef -t ioh/issue94 .
+docker run -t ioh/issue94 /usr/local/opt/ioh/test_store --gtest_filter=BaseTest.store_properties XDebug

--- a/example/eafh.cpp
+++ b/example/eafh.cpp
@@ -23,7 +23,7 @@ void run(L& logger, const size_t samples, const size_t runs)
         for(size_t r = 0; r < runs; ++r) {
             IOH_DBG(progress, "> run:" << r);
             for(size_t s = 0; s < samples; ++s) {
-                (*pb)(common::random::doubles(pb->meta_data().n_variables);
+                (*pb)(common::random::doubles(pb->meta_data().n_variables));
             }
             pb->reset();
         }

--- a/include/ioh/logger/analyzer.hpp
+++ b/include/ioh/logger/analyzer.hpp
@@ -360,7 +360,7 @@ namespace ioh::logger
                 }
 
                 //! Accessor for output directory
-                virtual fs::path output_directory() const { return path_.path(); }
+                virtual fs::path output_directory() const override { return path_.path(); }
 
             private:
                 static inline watch::Evaluations evaluations_{R"#("function evaluation")#"};

--- a/tests/cpp/logger/test_store.cpp
+++ b/tests/cpp/logger/test_store.cpp
@@ -39,6 +39,61 @@ TEST_F(BaseTest, store_data_consistency)
 
 }
 
+TEST_F(BaseTest, issue94)
+{
+    using namespace ioh;
+
+    auto sample_size = 2;
+    auto nb_runs = 2;
+
+    suite::BBOB suite({1,2}, {1}, {3}); // problems, instances, dimensions
+
+
+    double* nullp = nullptr;
+    EXPECT_DEBUG_DEATH( watch::Pointer nope("Nope", nullp), "");
+
+    double* p_transient_att = nullptr;
+    watch::PointerReference attpr("Att_PtrRef", p_transient_att);
+    IOH_DBG(xdebug, "@ " << attpr.ref_ptr_var() << " -> " << p_transient_att);
+    
+    trigger::Always always;
+    logger::Store logger({always},{attpr});
+    suite.attach_logger(logger);
+
+    double my_attribute = 100;
+    for (const auto &pb : suite) {
+        IOH_DBG(progress, "Problem");
+        for (auto r = 0; r < nb_runs; r++) {
+            IOH_DBG(progress, "Run " << r);
+            for (auto s = 0; s < sample_size; ++s) {
+                IOH_DBG(progress, "Sample " << s);
+
+                if(s >= sample_size/2) {
+                    IOH_DBG(progress, "available attribute");
+                    p_transient_att = &my_attribute;
+                    IOH_DBG(xdebug, "@ " << p_transient_att << " == " << *p_transient_att << " == " << my_attribute);
+                } else {
+                    IOH_DBG(progress, "unavailable attribute");
+                    p_transient_att = nullptr;
+                    IOH_DBG(xdebug, "@ " << p_transient_att << " == nullptr");
+                }
+                // ref_ptr_var is a member only available under NDEBUG
+                IOH_DBG(xdebug, "@ " << attpr.ref_ptr_var() << " -> " << p_transient_att << " -> " << &my_attribute );
+                (*pb)(common::random::pbo::uniform(pb->meta_data().n_variables, 0));
+                my_attribute++;
+            }
+            pb->reset();
+        }
+    }
+
+    logger::Store::Cursor first_eval(suite.name(), /*pb*/1, /*dim*/3, /*ins*/1, /*run*/0, /*eval*/0);
+
+    ASSERT_EQ(logger.at(first_eval, attpr), std::nullopt);
+    
+    logger::Store::Cursor last_eval(suite.name(), /*pb*/2, /*dim*/3, /*ins*/1, /*run*/1, /*eval*/sample_size-1);
+    ASSERT_EQ(logger.at(last_eval, attpr).value(), my_attribute-1);
+}
+
 TEST_F(BaseTest, store_properties)
 {
     using namespace ioh;
@@ -66,20 +121,16 @@ TEST_F(BaseTest, store_properties)
     logger::Store logger({always},{evaluations, raw_y_best, transformed_y, transformed_y_best, attr, attp, attpr});
     suite.attach_logger(logger);
 
-    // This is to ensure the test passes on gcc, no idea why this helps
-    // logger::Info info;
-    // attpr(info);
-
     for (const auto &pb : suite) {
         for (auto r = 0; r < nb_runs; r++) {
             for (auto s = 0; s < sample_size; ++s) {
-                (*pb)(common::random::pbo::uniform(pb->meta_data().n_variables, 0));
-                my_attribute++;
                 if(s > sample_size/2) {
                     p_transient_att = &my_attribute;
                 } else {
                     p_transient_att = nullptr;
                 }
+                (*pb)(common::random::pbo::uniform(pb->meta_data().n_variables, 0));
+                my_attribute++;
             }
             pb->reset();
         }
@@ -97,9 +148,8 @@ TEST_F(BaseTest, store_properties)
     ASSERT_EQ(logger.at(first_eval, attp ).value(), 0);
     ASSERT_EQ(logger.at(first_eval, attr ).value(), 0);
 
-    logger::Store::Cursor last_eval(suite.name(), /*pb*/1, /*dim*/3, /*ins*/1, /*run*/0, /*eval*/sample_size-1);
-    ASSERT_EQ(logger.at(last_eval, attp ).value(), 3);
-    ASSERT_EQ(logger.at(last_eval, attr ).value(), 3);
-    ASSERT_EQ(logger.at(last_eval, attpr), std::nullopt);
+    logger::Store::Cursor last_eval(suite.name(), /*pb*/2, /*dim*/10, /*ins*/2, /*run*/nb_runs-1, /*eval*/sample_size-1);
+    ASSERT_EQ(logger.at(last_eval, attp ).value(), my_attribute-1);
+    ASSERT_EQ(logger.at(last_eval, attr ).value(), my_attribute-1);
+    ASSERT_EQ(logger.at(last_eval, attpr).value(), my_attribute-1);
 }
-


### PR DESCRIPTION
Fixed by decoupling the type declaration, so instead of a single `const T *const &`, we now have several type definitions.

This apparently helps the compilers (tested on clang++-9 and g++-8) because the code runs well and both compilers raise (different) warnings about some (different) `const` qualifier not being taken into account.