### PR TITLE
move enable_testing in root CMakeLists to enable ctest from root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ export(PACKAGE ioh)
 
 # Add subdirectories to build.
 if(BUILD_TESTS) 
+    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,6 @@
 ##
 add_subdirectory(${EXTERNAL_DIR}/googletest EXCLUDE_FROM_ALL build)
 include(GoogleTest)
-enable_testing()
 
 function(register_test test_name test_sources)
     add_executable(${test_name} ${test_sources} cpp/utils.hpp cpp/entrypoint.cpp)


### PR DESCRIPTION
Avoid the necessity to go to a subdir to run tests.