### PR TITLE
fix(log): do not log errors on cout

### DIFF
--- a/include/ioh/logger/loggers.hpp
+++ b/include/ioh/logger/loggers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ioh/common/log.hpp>
 #include "triggers.hpp"
 #include "properties.hpp"
 
@@ -114,8 +115,8 @@ namespace ioh {
         , problem_(nullptr)
         {
             //  auto ref = properties_.at("Att_PtrRef");
-            //     std::cout << "ref addr " << &ref.get() << std::endl;
-            //     std::cout << ref.get()(log_info).value_or(-1) << std::endl;
+            //     IOH_DBG(debug, "ref addr " << &ref.get());
+            //     IOH_DBG(debug, ref.get()(log_info).value_or(-1));
             
             store_properties(properties);
             assert(consistent_properties());

--- a/include/ioh/logger/store.hpp
+++ b/include/ioh/logger/store.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <optional>
 
+#include <ioh/common/log.hpp>
 #include "loggers.hpp"
 
 namespace ioh::logger {

--- a/include/ioh/problem/python/extern_python.hpp
+++ b/include/ioh/problem/python/extern_python.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "extern_python_helper.hpp"
-#include "ioh/problem.hpp"
+#include <ioh/common/log.hpp>
+#include <ioh/problem.hpp>
 
 namespace ioh {
     namespace problem {

--- a/include/ioh/problem/structures.hpp
+++ b/include/ioh/problem/structures.hpp
@@ -4,8 +4,9 @@
 #include <utility>
 #include <vector>
 
-#include "ioh/common/optimization_type.hpp"
-#include "ioh/common/repr.hpp"
+#include <ioh/common/optimization_type.hpp>
+#include <ioh/common/repr.hpp>
+#include <ioh/common/log.hpp>
 
 namespace ioh
 {
@@ -96,7 +97,7 @@ namespace ioh
                 }
 
                 if ((ub.size() != static_cast<size_t>(s)) || (ub.size() != lb.size()))
-                    std::cout << "Bound dimension is wrong" << std::endl;
+                    IOH_DBG(error, "Bound dimension is wrong"); // FIXME raise an exception?
             }
 
             //! Check if the constraints are violated

--- a/include/ioh/problem/submodular/graph_problem.hpp
+++ b/include/ioh/problem/submodular/graph_problem.hpp
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include "ioh/problem/problem.hpp"
-#include "ioh/problem/transformation.hpp"
+#include <ioh/problem/problem.hpp>
+#include <ioh/problem/transformation.hpp>
+#include <ioh/common/log.hpp>
 
 #include <fstream>
 #include <limits>
@@ -38,7 +39,7 @@ namespace ioh
                     std::ifstream list_data(path_to_meta_list_instance);
                     if (!list_data)
                     {
-                        std::cout << "Fail to instance list file: " << path_to_meta_list_instance << std::endl;
+                        IOH_DBG(error, "Fail to instance list file: " << path_to_meta_list_instance ); // FIXME raise an exception?
                         return {};
                     }
                     instance_list_path = path_to_meta_list_instance;
@@ -145,7 +146,7 @@ namespace ioh
                                 }
                                 else
                                 {
-                                    std::cout << "Invalid edge file format" << std::endl;
+                                    IOH_DBG(error, "Invalid edge file format" ); // FIXME raise an exception?
                                     n_vertices=0;
                                     return;
                                 }
@@ -189,7 +190,7 @@ namespace ioh
                                 edge_weights[edge_indexes[index][0]][edge_indexes[index][1]] = temp;
                             else
                             {
-                                std::cout << "Invalid edge weights file format" << std::endl;
+                                IOH_DBG(error, "Invalid edge weights file format" ); // FIXME raise an exception?
                                 n_vertices = 0;
                                 return;
                             }
@@ -215,7 +216,7 @@ namespace ioh
                                 vertex_weights[index++] = temp;
                             else
                             {
-                                std::cout << "Invalid vertex weights file format" << std::endl;
+                                IOH_DBG(error, "Invalid vertex weights file format" ); // FIXME raise an exception?
                                 n_vertices = 0;
                                 return;
                             }
@@ -241,7 +242,7 @@ namespace ioh
                                 cons_weights.push_back(temp);
                             else
                             {
-                                std::cout << "Invalid constraint weights file format" << std::endl;
+                                IOH_DBG(error, "Invalid constraint weights file format" ); // FIXME raise an exception?
                                 n_vertices = 0;
                                 return;
                             }
@@ -290,7 +291,7 @@ namespace ioh
                     std::ifstream list_data(path_to_meta_list_graph);
                     if (!list_data)
                     {
-                        std::cout << "Fail to open instance list file: " << path_to_meta_list_graph << std::endl;
+                        IOH_DBG(error, "Fail to open instance list file: " << path_to_meta_list_graph ); // FIXME raise an exception?
                         is_initialized = false;
                         return 0;
                     }
@@ -346,8 +347,7 @@ namespace ioh
                 {
                     if (is_null())
                     {
-                        std::cout << "Invalid instance id. Skip creating instance oracle."
-                                  << std::endl;
+                        IOH_DBG(error, "Invalid instance id. Skip creating instance oracle." ); // FIXME raise an exception?
                         return;
                     }
                 }

--- a/include/ioh/problem/submodular/max_coverage.hpp
+++ b/include/ioh/problem/submodular/max_coverage.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 #include <stdexcept>
+#include <ioh/common/log.hpp>
 #include "graph_problem.hpp"
 
 namespace ioh
@@ -67,7 +68,7 @@ namespace ioh
                 {
                     if (is_null())
                     {
-                        std::cout << "Null MaxCoverage instance" << std::endl;
+                        IOH_DBG(error, "Null MaxCoverage instance"); // FIXME raise an exception?
                         return;
                     }
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);

--- a/include/ioh/problem/submodular/max_cut.hpp
+++ b/include/ioh/problem/submodular/max_cut.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 #include <stdexcept>
+#include <ioh/common/log.hpp>
 #include "graph_problem.hpp"
 
 namespace ioh
@@ -72,7 +73,7 @@ namespace ioh
                 {
                     if (is_null())
                     {
-                        std::cout << "Null MaxCut instance" << std::endl;
+                        IOH_DBG(error, "Null MaxCut instance"); // FIXME raise an exception?
                         return;
                     }
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);

--- a/include/ioh/problem/submodular/max_influence.hpp
+++ b/include/ioh/problem/submodular/max_influence.hpp
@@ -3,6 +3,7 @@
 #pragma once
 #include <queue>
 #include <stdexcept>
+#include <ioh/common/log.hpp>
 #include "graph_problem.hpp"
 
 namespace ioh
@@ -94,7 +95,7 @@ namespace ioh
                 {
                     if (is_null())
                     {
-                        std::cout << "Null MaxInfluence instance" << std::endl;
+                        IOH_DBG(error, "Null MaxInfluence instance"); // FIXME raise an exception?
                         return;
                     }
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);

--- a/include/ioh/problem/submodular/pack_while_travel.hpp
+++ b/include/ioh/problem/submodular/pack_while_travel.hpp
@@ -3,8 +3,9 @@
 #pragma once
 #include <fstream>
 #include <stdexcept>
-#include "ioh/problem/problem.hpp"
-#include "ioh/problem/transformation.hpp"
+#include <ioh/common/log.hpp>
+#include <ioh/problem/problem.hpp>
+#include <ioh/problem/transformation.hpp>
 
 namespace ioh
 {
@@ -43,31 +44,31 @@ namespace ioh
                     while (std::getline(ttp_data, str, eol) && index_line++ < 2); // Skip 2 lines, to line 3
                     int n_cities; // Number of locations
                     if (!Helper::is_int(str.substr(str.find_last_of(':') + 1), &n_cities)){
-                        std::cout << "Cannot read number of cities for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read number of cities for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     std::getline(ttp_data, str, eol); // Number of items
                     if (!Helper::is_int(str.substr(str.find_last_of(':') + 1), &n_items))
                     {
-                        std::cout << "Cannot read number of items for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read number of items for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     std::getline(ttp_data, str, eol); // Carry capacity
                     if (!Helper::is_double(str.substr(str.find_last_of(':') + 1), &capacity))
                     {
-                        std::cout << "Cannot read carry capacity for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read carry capacity for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     std::getline(ttp_data, str, eol); // Minimum velocity
                     if (!Helper::is_double(str.substr(str.find_last_of(':') + 1), &velocity_gap))
                     {
-                        std::cout << "Cannot read minimum velocity for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read minimum velocity for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     std::getline(ttp_data, str, eol); // Maximum velocity
                     if (!Helper::is_double(str.substr(str.find_last_of(':') + 1), &velocity_max))
                     {
-                        std::cout << "Cannot read maximum velocity for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read maximum velocity for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     velocity_gap = velocity_max - velocity_gap;
@@ -75,7 +76,7 @@ namespace ioh
                     double rent_ratio; // Rent ratio
                     if (!Helper::is_double(str.substr(str.find_last_of(':') + 1), &rent_ratio))
                     {
-                        std::cout << "Cannot read rent ratio for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read rent ratio for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     while (std::getline(ttp_data, str, eol) && index_line++ < 5) // Skip 2 lines, to line 11
@@ -85,7 +86,7 @@ namespace ioh
                     if (!Helper::is_double(str.substr(first_space + 1, second_space - first_space - 1), &init_x) ||
                         !Helper::is_double(str.substr(second_space + 1), &init_y))
                     {
-                        std::cout << "Cannot read coordinates for PWT" << std::endl;
+                        IOH_DBG(error, "Cannot read coordinates for PWT"); // FIXME raise an exception?
                         return 1; // return a valid dummy size
                     }
                     cur_x = init_x;
@@ -103,7 +104,7 @@ namespace ioh
                         if (!Helper::is_double(str.substr(first_space + 1, second_space - first_space - 1), &next_x) ||
                             !Helper::is_double(str.substr(second_space + 1), &next_y))
                         {
-                            std::cout << "Cannot read coordinates for PWT" << std::endl;
+                            IOH_DBG(error, "Cannot read coordinates for PWT"); // FIXME raise an exception?
                             return 1; // return a valid dummy size
                         }
                         distance =
@@ -139,7 +140,7 @@ namespace ioh
                         }
                         else
                         {
-                            std::cout << "Cannot read item profits for PWT" << std::endl;
+                            IOH_DBG(error, "Cannot read item profits for PWT"); // FIXME raise an exception?
                             return 1; // return a valid dummy size
                         }
                         if (Helper::is_double(tstr.substr(first_space + 1, second_space - first_space - 1), &temp))
@@ -148,7 +149,7 @@ namespace ioh
                         }
                         else
                         {
-                            std::cout << "Cannot read item weights for PWT" << std::endl;
+                            IOH_DBG(error, "Cannot read item weights for PWT"); // FIXME raise an exception?
                             return 1; // return a valid dummy size
                         }
                     }
@@ -206,7 +207,7 @@ namespace ioh
                 {
                     if (is_null())
                     {
-                        std::cout << "Instance not created properly (e.g. invalid id)." << std::endl;
+                        IOH_DBG(error, "Instance not created properly (e.g. invalid id)."); // FIXME raise an exception?
                         return;
                     }
                     if (velocity_gap >= velocity_max || velocity_gap <= 0 || velocity_max <= 0)


### PR DESCRIPTION

Replace explicit output on cout by error output on the logging system. This is necessary because an executable using IOH may need to control its output (e.g. a solver involved in hyper-parameter setting). By using IOH_DBG instead of raw cout, the output goes on cerr and an be filtered, avoiding most of issues.

This also adds a FIXME tag, because the fixed outputs probably need to be raised exceptions.

Use absolute includes when referencing absolute paths (keep the relative ones).