### PR TITLE
Reduce memory usage in Max Coverage and Max Influence evaluations

### DIFF
--- a/include/ioh/problem/submodular/max_coverage.hpp
+++ b/include/ioh/problem/submodular/max_coverage.hpp
@@ -16,12 +16,12 @@ namespace ioh
             class MaxCoverage final : public GraphProblem<MaxCoverage>
             {
             private:
-                bool *is_covered = nullptr;
+                std::unique_ptr<bool[]> is_covered;
             protected:
                 // [mandatory] The evaluate method is mandatory to implement
                 double evaluate(const std::vector<int> &x) override
                 {
-                    std::fill_n(is_covered, graph->get_n_vertices(), false);
+                    std::fill_n(is_covered.get(), graph->get_n_vertices(), false);
                     double result = 0, cons_weight = 0;
                     int index = 0, count = 0;
                     for (auto &selected : x)
@@ -73,7 +73,7 @@ namespace ioh
                         IOH_DBG(warning, "Null MaxCoverage instance")
                         return;
                     }
-                    is_covered = new bool[graph->get_n_vertices()]{0};
+                    is_covered = std::make_unique<bool[]>(graph->get_n_vertices());
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);
                     objective_.y = evaluate(objective_.x);
                 }

--- a/include/ioh/problem/submodular/max_coverage.hpp
+++ b/include/ioh/problem/submodular/max_coverage.hpp
@@ -49,6 +49,7 @@ namespace ioh
                     if (cons_weight > graph->get_cons_weight_limit()) // If the weight limit is exceeded (violating
                                                                       // constraint), return a penalized value
                         result = graph->get_cons_weight_limit() - cons_weight;
+                    delete[] is_covered;
                     return result;
                 }
 

--- a/include/ioh/problem/submodular/max_coverage.hpp
+++ b/include/ioh/problem/submodular/max_coverage.hpp
@@ -15,11 +15,13 @@ namespace ioh
             // Description: refer to Evolutionary Submodular Optimization website at https://cs.adelaide.edu.au/~optlog/CompetitionESO2022.php
             class MaxCoverage final : public GraphProblem<MaxCoverage>
             {
+            private:
+                bool *is_covered = nullptr;
             protected:
                 // [mandatory] The evaluate method is mandatory to implement
                 double evaluate(const std::vector<int> &x) override
                 {
-                    bool *is_covered = new bool[graph->get_n_vertices()]{0};
+                    std::fill_n(is_covered, graph->get_n_vertices(), false);
                     double result = 0, cons_weight = 0;
                     int index = 0, count = 0;
                     for (auto &selected : x)
@@ -49,7 +51,6 @@ namespace ioh
                     if (cons_weight > graph->get_cons_weight_limit()) // If the weight limit is exceeded (violating
                                                                       // constraint), return a penalized value
                         result = graph->get_cons_weight_limit() - cons_weight;
-                    delete[] is_covered;
                     return result;
                 }
 
@@ -72,6 +73,7 @@ namespace ioh
                         IOH_DBG(warning, "Null MaxCoverage instance")
                         return;
                     }
+                    is_covered = new bool[graph->get_n_vertices()]{0};
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);
                     objective_.y = evaluate(objective_.x);
                 }

--- a/include/ioh/problem/submodular/max_influence.hpp
+++ b/include/ioh/problem/submodular/max_influence.hpp
@@ -18,7 +18,7 @@ namespace ioh
             class MaxInfluence final : public GraphProblem<MaxInfluence>
             {
             private:
-                bool *is_activated = nullptr;
+                std::unique_ptr<bool[]> is_activated;
                 int simulation_reps = 100;
                 // Simulate Independent Cascade Model with seed and return weighted sum of activated nodes other than
                 // seeds
@@ -102,7 +102,7 @@ namespace ioh
                         IOH_DBG(warning, "Null MaxInfluence instance")
                         return;
                     }
-                    is_activated = new bool[graph->get_n_vertices()]{0};
+                    is_activated = std::make_unique<bool[]>(graph->get_n_vertices());
                     objective_.x = std::vector<int>(graph->get_n_vertices(), 1);
                     objective_.y = evaluate(objective_.x);
                 }

--- a/include/ioh/problem/submodular/max_influence.hpp
+++ b/include/ioh/problem/submodular/max_influence.hpp
@@ -48,6 +48,7 @@ namespace ioh
                             subIndex++;
                         }
                     }
+                    delete[] is_activated;
                     return total;
                 }
 


### PR DESCRIPTION
Add delete[] to raw pointers in evaluation functions. This eliminates memory bloats, reduces chance of segfault, and slightly improves runtime.