### PR TITLE
Change relative link to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The complete API documentation, can be found [here](https://iohprofiler.github.i
 
 ## Python
 
-The pip-version of IOHexperimenters python interface is available via [pip](https://pypi.org/project/ioh). A tutorial with python in the form of a jupyter notebook can be found in the example folder of [this repository](./example/tutorial.ipynb).
+The pip-version of IOHexperimenters python interface is available via [pip](https://pypi.org/project/ioh). A tutorial with python in the form of a jupyter notebook can be found in the example folder of [this repository](https://github.com/IOHprofiler/IOHexperimenter/blob/master/example/tutorial.ipynb).
 A Getting-Started guide and the full API documentation can be found [here](https://iohprofiler.github.io/IOHexperimenter/python).
 
 ## Contact


### PR DESCRIPTION
Change relative link to absolute. It worked only from the repository, not from the wiki/webpage: https://iohprofiler.github.io/IOHexperimenter/