### PR TITLE
Add experiment publish helper and Zenodo integration (#5)

### DIFF
--- a/doc/python/source/api/ioh.Experiment.rst
+++ b/doc/python/source/api/ioh.Experiment.rst
@@ -16,6 +16,7 @@ Experiment
       ~Experiment.evaluate
       ~Experiment.merge_output_to_single_folder
       ~Experiment.merge_tmp_folders
+      ~Experiment.publish
       ~Experiment.run
 
    .. rubric:: Methods Documentation

--- a/doc/python/source/python.rst
+++ b/doc/python/source/python.rst
@@ -17,4 +17,5 @@ API documentation
    python/structures.rst
    python/ioh.rst
    python/logger.rst
-   python/suite.rst 
+   python/suite.rst
+   python/publish.rst

--- a/doc/python/source/python/publish.rst
+++ b/doc/python/source/python/publish.rst
@@ -1,0 +1,45 @@
+Publishing experiment archives
+==============================
+
+The :meth:`ioh.Experiment.publish` helper streamlines turning an experiment run
+into a shareable Zenodo deposit. After running an experiment, calling
+``publish`` will:
+
+* generate the ``ioh_data.zip`` archive with an up-to-date ``README.md``
+  describing the algorithm, problems, instances, dimensions, repetitions and
+  optional evaluation budget;
+* serialise the algorithm instance with :mod:`cloudpickle` so it can be
+  restored when reproducing the experiment; and
+* upload the archive, README and algorithm bundle to Zenodo using their REST
+  API.
+
+> [!IMPORTANT] You need a Zenodo access token with appropriate permissions to upload
+> deposits. You can create and manage your tokens in your Zenodo account
+> settings. See https://zenodo.org/account/settings/applications/tokens/new/
+
+Example usage::
+
+    exp = ioh.Experiment(
+        my_algorithm,
+        fids=[1, 2, 3],
+        iids=[1],
+        dims=[5, 10],
+        reps=5,
+    )
+    exp()  # run the benchmark
+    exp.publish(
+        zenodo_token="<your access token>",
+        title="Benchmarking IOH on BBOB",
+        description="Log data for the benchmark run.",
+        creators=[{"name": "Doe, Jane"}],
+        budget=20000,
+        keywords=["optimization", "benchmark"],
+        sandbox=True,
+    )
+
+By default the helper targets the production Zenodo endpoint. Pass
+``sandbox=True`` while testing credentials or automation against the sandbox
+service. You can also provide an existing :class:`requests.Session` to reuse
+connections or configure proxies, and the ``additional_metadata`` parameter to
+add any extra Zenodo metadata fields.
+

--- a/example/python_example_publish.py
+++ b/example/python_example_publish.py
@@ -1,0 +1,37 @@
+import ioh
+import numpy as np
+
+class RandomSearch:
+    'Simple random search algorithm'
+    def __init__(self, n: int, length: float = 0.0):
+        self.n: int = n
+        self.length: float = length
+        
+    def __call__(self, problem: ioh.problem.RealSingleObjective) -> None:
+        'Evaluate the problem n times with a randomly generated solution'
+        
+        for _ in range(self.n):
+            # We can use the problems bounds accessor to get information about the problem bounds
+            x = np.random.uniform(problem.bounds.lb, problem.bounds.ub)
+            self.length = np.linalg.norm(x)
+            
+            problem(x)             
+budget = 1000
+my_algorithm = RandomSearch(n=budget)
+exp = ioh.Experiment(
+    my_algorithm,
+    fids=[1, 2, 3],
+    iids=[1],
+    dims=[5, 10],
+    reps=5,
+)
+exp()  # run the benchmark
+exp.publish(
+    zenodo_token="<your token here>",
+    title="Benchmarking IOH publish example",
+    description="Log data for the benchmark run.",
+    creators=[{"name": "van Stein, Niki"}],
+    budget=budget,
+    keywords=["optimization", "benchmark", "ioh"],
+    sandbox=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -174,5 +174,9 @@ setup(
     ],
     license="BSD",
     url="https://iohprofiler.github.io/IOHexperimenter",
-    install_requires=["numpy>=2.0"]
+    install_requires=[
+        "numpy>=2.0",
+        "requests>=2.0",
+        "cloudpickle>=2.0",
+    ]
 )


### PR DESCRIPTION
* Add experiment publish helper and Zenodo integration
* Cleaning up readme template


@Dvermetten, I was thinking that something *like* this, would perhaps be useful for users.  
This is a far from ideal implementation as it is limited to Zenodo, and only useful when you use the standard ioh.Experiment class and standard benchmark functions. Cloudpickle could of course also be used for the additional wrapped problems, but it gets tricky to do nicely (especially across hardware changes and library changes).  
However, it could serve as an example that we can slowly expand to also include other platforms, like the future OpenOpt platform.  

PS: Don't merge this, this is just for brainstorming. (It is tested and working (not vibe coded :P ), but still would not be in favor of merging at this point).